### PR TITLE
Fix the LCS matrix calculation for strings longer the 64 chars.

### DIFF
--- a/FuzzySharp.Test/LongestCommonSubsequenceTests.cs
+++ b/FuzzySharp.Test/LongestCommonSubsequenceTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using NUnit.Framework;
+using Raffinert.FuzzySharp.Edits;
+
+namespace Raffinert.FuzzySharp.Test;
+
+public class LongestCommonSubsequenceTests
+{
+    [Test]
+    public void LongestCommonSubsequence_MatchingBlocks_ReturnsExpectedEditOps()
+    {
+        var lcsBlocks = LongestCommonSubsequence.MatchingBlocks("xasdfxxxxxxxxxxxxxxxxxxxasdfxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxasdfx".AsSpan(), "aabbcc".AsSpan());
+        Assert.That(lcsBlocks, Is.EquivalentTo(new[]
+        {
+            new MatchingBlock
+            {
+                SourcePos = 1,
+                Length = 1
+            },
+            new MatchingBlock
+            {
+                SourcePos = 24,
+                DestPos = 1,
+                Length = 1
+            },
+            new MatchingBlock
+            {
+                SourcePos = 73,
+                DestPos = 6,
+                Length = 0
+            }}));
+    }
+}

--- a/FuzzySharp/FuzzySharp.csproj
+++ b/FuzzySharp/FuzzySharp.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <FileVersion>5.0.0.0</FileVersion>
-    <Version>5.0.0</Version>
-    <PackageVersion>5.0.0</PackageVersion>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
-    <FileVersion>5.0.0.0</FileVersion>
-    <Version>5.0.0</Version>
-    <PackageVersion>5.0.0</PackageVersion>
+    <FileVersion>5.0.1.0</FileVersion>
+    <Version>5.0.1</Version>
+    <PackageVersion>5.0.1</PackageVersion>
+    <AssemblyVersion>5.0.1.0</AssemblyVersion>
+    <FileVersion>5.0.1.0</FileVersion>
+    <Version>5.0.1</Version>
+    <PackageVersion>5.0.1</PackageVersion>
     <Authors>Jacob Bayer;Yevhen Cherkes</Authors>
     <Company />
     <Description>

--- a/FuzzySharp/LongestCommonSubsequence.Static.cs
+++ b/FuzzySharp/LongestCommonSubsequence.Static.cs
@@ -504,46 +504,43 @@ public sealed partial class LongestCommonSubsequence
         using var blockTable = PatternMatchVector.Create(s1);
 
         var matrix = new List<ulong[]>(s2.Length);
-        var And = new ulong[blocks];
-        var Sum = new ulong[blocks];
-        var Diff = new ulong[blocks];
+        var sum = new ulong[blocks];
+        var diff = new ulong[blocks];
 
         foreach (var y in s2)
         {
             // load mask for y
             var U = blockTable.GetOrZero(y);
 
-            // big-integer add: Sum = S + u
+            // big-integer add/subtract using u = S & U
             ulong carry = 0;
+            ulong borrow = 0;
             for (int b = 0; b < blocks; b++)
             {
                 // u = S & U
-                ulong u = And[b] = S[b] & U[b];
                 ulong s = S[b];
+                ulong u = s & U[b];
+
+                // Sum = S + u
                 ulong t = unchecked(s + u);
                 ulong c1 = t < s ? 1UL : 0UL;
                 ulong t2 = unchecked(t + carry);
                 ulong c2 = t2 < t ? 1UL : 0UL;
-                Sum[b] = t2;
+                sum[b] = t2;
                 carry = c1 | c2;
-            }
 
-            // big-integer subtract: Diff = S - u
-            ulong borrow = 0;
-            for (int b = 0; b < blocks; b++)
-            {
-                ulong s = S[b], u = And[b];
+                // Diff = S - u
                 ulong t1 = unchecked(s - u);
                 ulong b1 = s < u ? 1UL : 0UL;
-                ulong t2 = unchecked(t1 - borrow);
+                ulong t3 = unchecked(t1 - borrow);
                 ulong b2 = t1 < borrow ? 1UL : 0UL;
-                Diff[b] = t2;
+                diff[b] = t3;
                 borrow = b1 | b2;
             }
 
             // update S = Sum | Diff
             for (int b = 0; b < blocks; b++)
-                S[b] = Sum[b] | Diff[b];
+                S[b] = sum[b] | diff[b];
 
             // snapshot row
             matrix.Add((ulong[])S.Clone());
@@ -561,7 +558,7 @@ public sealed partial class LongestCommonSubsequence
             return (0, new List<ulong[]>(s2.Length));
 
         int m = s1.Length;
-        ulong S = m == 64 ? ulong.MaxValue : (1UL << m) - 1UL;
+        ulong s = m == 64 ? ulong.MaxValue : (1UL << m) - 1UL;
 
         // build bit-mask
         using var block = PatternMatchVector.Create(s1);
@@ -571,13 +568,13 @@ public sealed partial class LongestCommonSubsequence
         {
             var M = block.GetOrZero(y)[0];
 
-            ulong u = S & M;
+            ulong u = s & M;
 
-            unchecked { S = (S + u) | (S - u); }
-            matrix.Add([S]);
+            unchecked { s = (s + u) | (s - u); }
+            matrix.Add([s]);
         }
 
-        int sim = CountZeroBits(S, m);
+        int sim = CountZeroBits(s, m);
         return (sim, matrix);
     }
 }

--- a/FuzzySharp/LongestCommonSubsequence.Static.cs
+++ b/FuzzySharp/LongestCommonSubsequence.Static.cs
@@ -504,6 +504,7 @@ public sealed partial class LongestCommonSubsequence
         using var blockTable = PatternMatchVector.Create(s1);
 
         var matrix = new List<ulong[]>(s2.Length);
+        var And = new ulong[blocks];
         var Sum = new ulong[blocks];
         var Diff = new ulong[blocks];
 
@@ -512,11 +513,13 @@ public sealed partial class LongestCommonSubsequence
             // load mask for y
             var U = blockTable.GetOrZero(y);
 
-            // big-integer add: Sum = S + U
+            // big-integer add: Sum = S + u
             ulong carry = 0;
             for (int b = 0; b < blocks; b++)
             {
-                ulong s = S[b], u = U[b];
+                // u = S & U
+                ulong u = And[b] = S[b] & U[b];
+                ulong s = S[b];
                 ulong t = unchecked(s + u);
                 ulong c1 = t < s ? 1UL : 0UL;
                 ulong t2 = unchecked(t + carry);
@@ -525,11 +528,11 @@ public sealed partial class LongestCommonSubsequence
                 carry = c1 | c2;
             }
 
-            // big-integer subtract: Diff = S - U
+            // big-integer subtract: Diff = S - u
             ulong borrow = 0;
             for (int b = 0; b < blocks; b++)
             {
-                ulong s = S[b], u = U[b];
+                ulong s = S[b], u = And[b];
                 ulong t1 = unchecked(s - u);
                 ulong b1 = s < u ? 1UL : 0UL;
                 ulong t2 = unchecked(t1 - borrow);


### PR DESCRIPTION
# PR Summary

Fixes #25

## Branch Scope

This summary describes the changes currently committed on branch `fix-lsc-matrix-for-string-longer-64-chars`.

Commits included:

- `cd71044` Fix the LCS matrix calculation for strings longer the 64 chars.
- `595a107` v++, put all calculations into single loop

## Problem

`LongestCommonSubsequenceTests` exposed a failure in the multi-word LCS matrix path (the path used when `s1.Length > 64`).

The incorrect matrix state appeared very early (second row during reconstruction), which propagated into wrong backtracking for edit operations and matching blocks.

## Root Cause

In `MatrixMultipleULongs` the transition logic diverged from RapidFuzz.

Incorrect behavior (before fix):

- `Sum = S + U`
- `Diff = S - U`
- `S = Sum | Diff`

Correct RapidFuzz behavior:

- `u = S & M` (here `M` is this codebase's `U` mask)
- `S = (S + u) | (S - u)`

Using `U` directly instead of `S & U` over-applies bit transitions and corrupts row snapshots.

## Source of Truth

The fix was aligned to these references:

- Python: `https://github.com/rapidfuzz/RapidFuzz/blob/main/src/rapidfuzz/distance/LCSseq_py.py`
- C++: `https://github.com/rapidfuzz/rapidfuzz-cpp/blob/main/rapidfuzz/distance/LCSseq_impl.hpp`

Both implement the same update structure: derive `u` via `S & mask`, then compute `(S + u) | (S - u)`.

## What Was Fixed

File changed:

- `FuzzySharp/LongestCommonSubsequence.Static.cs`

Method changed:

- `MatrixMultipleULongs<T>(ReadOnlySpan<T> s1, ReadOnlySpan<T> s2)`

Functional corrections:

1. Replaced use of raw mask in arithmetic with `u = S & U`.
2. Preserved carry/borrow multi-precision behavior across 64-bit blocks.
3. Kept row snapshots (`matrix.Add((ulong[])S.Clone())`) based on corrected `S` values.

Follow-up optimization in the second commit:

1. Merged add and subtract passes into a single block loop.
2. Compute `u` once per block and immediately apply it to both:
   - `Sum[b] = S[b] + u (+carry)`
   - `Diff[b] = S[b] - u (-borrow)`
3. Removed temporary `And` buffer since separate storage was no longer needed.

This reduces memory traffic and loop overhead while keeping semantics identical.

## Why Single Loop Is Correct

The combined loop is mathematically equivalent because each block uses:

- the same row input `S[b]`
- the same symbol mask `U[b]`
- the same derived `u = S[b] & U[b]`

`S` is only overwritten after all blocks finish (`S[b] = Sum[b] | Diff[b]`), so add/sub calculations are still based on the original row state.

## Validation

Command executed:

```bash
dotnet test FuzzySharp.Test/FuzzySharp.Test.csproj --filter "FullyQualifiedName~LongestCommonSubsequenceTests"
```

Result:

- Passed on `net462`, `net472`, `net8.0`, and `net10.0`.

## Impact

- Fixes LCS matrix correctness for long inputs (`>64` symbols).
- Fixes downstream correctness in:
  - `GetEditOps`
  - `MatchingBlocks`
  - any matrix-driven LCS backtracking behavior.
