### PR TITLE
Fix/lcs levenshtein bitparallel parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v5.0.2
+
+*Levenshtein/LCS correctness and cutoff semantics*
+
+- Fixed `Levenshtein.Distance<T>` weighted dispatch so non-fast-path weights correctly use `GenericDistance` and return the computed value.
+- Corrected `LevenshteinMaximum` length-difference math and aligned `Similarity` cutoff handling with RapidFuzz semantics by converting similarity cutoffs to distance cutoffs.
+- Fixed `NormalizedSimilarity` cutoff flow to use the corresponding normalized-distance cutoff (`1 - similarityCutoff`).
+- Made Levenshtein cutoff short-circuit strict-safe in both single- and multi-block paths using a remaining-length lower bound (`dist > cutoff + remaining`).
+- Added Levenshtein tests for weighted cases, cutoff behavior, maximum formula, and recoverable-prefix cutoff safety.
+- Updated multi-block LCS update logic and matrix construction to use the correct `u = S & U` transition form with consolidated per-block loops.
+
 ## v5.0.1
 
 *LongestCommonSubsequence matrix correctness for long inputs*

--- a/FuzzySharp.Test/DictionarySlimTests.cs
+++ b/FuzzySharp.Test/DictionarySlimTests.cs
@@ -1,13 +1,13 @@
-﻿using NUnit.Framework;
+using Xunit;
 using Raffinert.FuzzySharp.Utils;
 using System.Collections.Generic;
 
 namespace Raffinert.FuzzySharp.Test;
 
-[TestFixture]
 public class DictionarySlimTests
 {
-    [Test, TestCaseSource(typeof(RandomWordPairs), nameof(RandomWordPairs.GetWordPairs))]
+    [Theory]
+    [MemberData(nameof(RandomWordPairs.GetWordPairs), MemberType = typeof(RandomWordPairs))]
     public void DictionarySlim_And_Dictionary_ShouldHaveEqualResults(string s1, string s2)
     {
         var ds1 = new DictionarySlimPooled<char, int>(64);
@@ -24,7 +24,7 @@ public class DictionarySlimTests
         foreach (var c in s1)
         {
             Assert.True(ds1.TryGetValue(c, out var value));
-            Assert.AreEqual(value, d1[c]);
+            Assert.Equal(value, d1[c]);
         }
 
         var ds2 = new DictionarySlimPooled<char, int>(64);
@@ -42,7 +42,8 @@ public class DictionarySlimTests
         foreach (var c in s2)
         {
             Assert.True(ds2.TryGetValue(c, out var value));
-            Assert.AreEqual(value, d2[c]);
+            Assert.Equal(value, d2[c]);
         }
     }
 }
+

--- a/FuzzySharp.Test/EditOpsTests.cs
+++ b/FuzzySharp.Test/EditOpsTests.cs
@@ -1,12 +1,11 @@
-﻿using NUnit.Framework;
+using Xunit;
 using Raffinert.FuzzySharp.Edits;
 
 namespace Raffinert.FuzzySharp.Test;
 
-[TestFixture]
 public class EditOpsTests
 {
-    [Test]
+    [Fact]
     public void GetEditOps_KittenToSitting_ReturnsExpectedEditOps()
     {
         // Arrange
@@ -17,23 +16,23 @@ public class EditOpsTests
         var ops = Levenshtein.GetEditOps(source, target);
 
         // Assert
-        Assert.IsNotNull(ops);
-        Assert.AreEqual(3, ops.Length);
+        Assert.NotNull(ops);
+        Assert.Equal(3, ops.Length);
 
-        Assert.AreEqual(EditType.REPLACE, ops[0].EditType);
-        Assert.AreEqual(0, ops[0].SourcePos);
-        Assert.AreEqual(0, ops[0].DestPos);
+        Assert.Equal(EditType.REPLACE, ops[0].EditType);
+        Assert.Equal(0, ops[0].SourcePos);
+        Assert.Equal(0, ops[0].DestPos);
 
-        Assert.AreEqual(EditType.REPLACE, ops[1].EditType);
-        Assert.AreEqual(4, ops[1].SourcePos);
-        Assert.AreEqual(4, ops[1].DestPos);
+        Assert.Equal(EditType.REPLACE, ops[1].EditType);
+        Assert.Equal(4, ops[1].SourcePos);
+        Assert.Equal(4, ops[1].DestPos);
 
-        Assert.AreEqual(EditType.INSERT, ops[2].EditType);
-        Assert.AreEqual(6, ops[2].SourcePos);
-        Assert.AreEqual(6, ops[2].DestPos);
+        Assert.Equal(EditType.INSERT, ops[2].EditType);
+        Assert.Equal(6, ops[2].SourcePos);
+        Assert.Equal(6, ops[2].DestPos);
     }
 
-    [Test]
+    [Fact]
     public void GetEditOps_putinIsWarCriminal_ReturnsExpectedEditOps()
     {
         // Arrange
@@ -43,7 +42,7 @@ public class EditOpsTests
         // Act
         var ops = Levenshtein.GetEditOps(source, target);
 
-        Assert.That(ops, Is.EquivalentTo(new[]
+        Assert.Equivalent(ops, new[]
         {
             new EditOp
             {
@@ -105,6 +104,6 @@ public class EditOpsTests
                 SourcePos = 5,
                 DestPos = 11
             }
-        }));
+        });
     }
 }

--- a/FuzzySharp.Test/EvaluationTests/EvaluationTests.cs
+++ b/FuzzySharp.Test/EvaluationTests/EvaluationTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+using Xunit;
 using Raffinert.FuzzySharp.PreProcess;
 using Raffinert.FuzzySharp.SimilarityRatio;
 using Raffinert.FuzzySharp.SimilarityRatio.Scorer.Composite;
@@ -8,10 +8,9 @@ using System.Linq;
 
 namespace Raffinert.FuzzySharp.Test.EvaluationTests;
 
-[TestFixture]
 public class EvaluationTests
 {
-    [Test]
+    [Fact]
     public void Evaluate()
     {
         var a1 = Fuzz.Ratio("mysmilarstring", "myawfullysimilarstirng");
@@ -79,7 +78,7 @@ public class EvaluationTests
         var weighted = ScorerCache.Get<WeightedRatioScorer>();
     }
 
-    [Test]
+    [Fact]
     public void TokenInitialismScorer_WhenGivenStringWithTrailingSpaces_DoesNotBreak()
     {
         // arrange
@@ -90,12 +89,12 @@ public class EvaluationTests
         var ratio = Fuzz.TokenInitialismRatio(shorter, longer);
 
         // assert
-        Assert.IsTrue(ratio >= 0);
+        Assert.True(ratio >= 0);
     }
 
     [Theory]
-    [TestCase("+30.0% Damage to Close Enemies [30.01%", 1)]
-    [TestCase("+14.3% Damage to Crowd Controlled Enemies [7.5 - 18.0]%", 2)]
+    [InlineData("+30.0% Damage to Close Enemies [30.01%", 1)]
+    [InlineData("+14.3% Damage to Crowd Controlled Enemies [7.5 - 18.0]%", 2)]
     public void FullPreprocessor(string input, int caseNumber)
     {
         // Arrange
@@ -118,18 +117,18 @@ public class EvaluationTests
         var regularResults = Process.ExtractTop(input, choices, limit: 2).ToArray();
 
         // Assert
-        Assert.IsNotEmpty(cachedResults);
-        Assert.IsNotEmpty(cachedParallelResults);
-        Assert.IsNotEmpty(regularResults);
-        Assert.AreEqual(regularResults[0].Value, cachedResults[0].Value, $"Case {caseNumber}: top match differs");
-        Assert.AreEqual(regularResults[0].Score, cachedResults[0].Score, $"Case {caseNumber}: top score differs");
-        Assert.AreEqual(cachedParallelResults[0].Value, cachedResults[0].Value, $"Case {caseNumber}: top match differs");
-        Assert.AreEqual(cachedParallelResults[0].Score, cachedResults[0].Score, $"Case {caseNumber}: top score differs");
+        Assert.NotEmpty(cachedResults);
+        Assert.NotEmpty(cachedParallelResults);
+        Assert.NotEmpty(regularResults);
+        Assert.True(regularResults[0].Value == cachedResults[0].Value, $"Case {caseNumber}: top match differs");
+        Assert.True(regularResults[0].Score == cachedResults[0].Score, $"Case {caseNumber}: top score differs");
+        Assert.True(cachedParallelResults[0].Value == cachedResults[0].Value, $"Case {caseNumber}: top match differs");
+        Assert.True(cachedParallelResults[0].Score == cachedResults[0].Score, $"Case {caseNumber}: top score differs");
     }
 
     [Theory]
-    [TestCase("+30.0% Damage to Close Enemies [30.01%", 1)]
-    [TestCase("+14.3% Damage to Crowd Controlled Enemies [7.5 - 18.0]%", 2)]
+    [InlineData("+30.0% Damage to Close Enemies [30.01%", 1)]
+    [InlineData("+14.3% Damage to Crowd Controlled Enemies [7.5 - 18.0]%", 2)]
     public void NonePreprocessor(string input, int caseNumber)
     {
         // Arrange
@@ -152,12 +151,13 @@ public class EvaluationTests
         var cachedResults = Process.Configure().Cached().Build().ExtractTop(input, choices, processor: StringPreprocessor.None, limit: 2).ToArray();
 
         // Assert
-        Assert.IsNotEmpty(cachedResults);
-        Assert.IsNotEmpty(cachedParallelResults);
-        Assert.IsNotEmpty(regularResults);
-        Assert.AreEqual(regularResults[0].Value, cachedResults[0].Value, $"Case {caseNumber}: top match differs");
-        Assert.AreEqual(regularResults[0].Score, cachedResults[0].Score, $"Case {caseNumber}: top score differs");
-        Assert.AreEqual(cachedParallelResults[0].Value, cachedResults[0].Value, $"Case {caseNumber}: top match differs");
-        Assert.AreEqual(cachedParallelResults[0].Score, cachedResults[0].Score, $"Case {caseNumber}: top score differs");
+        Assert.NotEmpty(cachedResults);
+        Assert.NotEmpty(cachedParallelResults);
+        Assert.NotEmpty(regularResults);
+        Assert.True(regularResults[0].Value == cachedResults[0].Value, $"Case {caseNumber}: top match differs");
+        Assert.True(regularResults[0].Score == cachedResults[0].Score, $"Case {caseNumber}: top score differs");
+        Assert.True(cachedParallelResults[0].Value == cachedResults[0].Value, $"Case {caseNumber}: top match differs");
+        Assert.True(cachedParallelResults[0].Score == cachedResults[0].Score, $"Case {caseNumber}: top score differs");
     }
 }
+

--- a/FuzzySharp.Test/FuzzySharp.Test.csproj
+++ b/FuzzySharp.Test/FuzzySharp.Test.csproj
@@ -10,14 +10,13 @@
 
   <ItemGroup>
     <PackageReference Include="FuzzySharp" Version="2.0.2" />
-    <PackageReference Include="nunit" Version="3.14.0" />
-    <PackageReference Include="NUnit.Console" Version="3.20.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Quickenshtein" Version="1.5.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Quickenshtein" Version="1.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FuzzySharp.Test/FuzzyTests/ProcessPipelineTests.cs
+++ b/FuzzySharp.Test/FuzzyTests/ProcessPipelineTests.cs
@@ -2,29 +2,22 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using NUnit.Framework;
+using Xunit;
 using Raffinert.FuzzySharp.SimilarityRatio.Scorer.Composite;
 
 namespace Raffinert.FuzzySharp.Test.FuzzyTests;
 
-[TestFixture]
 public class ProcessPipelineTests
 {
-    private string[] _baseballStrings;
-
-    [SetUp]
-    public void Setup()
+    private readonly string[] _baseballStrings = new[]
     {
-        _baseballStrings = new[]
-        {
-            "new york mets vs chicago cubs",
-            "chicago cubs vs chicago white sox",
-            "philladelphia phillies vs atlanta braves",
-            "braves vs mets",
-        };
-    }
+        "new york mets vs chicago cubs",
+        "chicago cubs vs chicago white sox",
+        "philladelphia phillies vs atlanta braves",
+        "braves vs mets",
+    };
 
-    [Test]
+    [Fact]
     public void TestOrderIndependence_CachedThenParallel()
     {
         var query = "new york mets at atlanta braves";
@@ -42,12 +35,12 @@ public class ProcessPipelineTests
         var result1 = pipeline1.ExtractOne(query, _baseballStrings);
         var result2 = pipeline2.ExtractOne(query, _baseballStrings);
 
-        Assert.AreEqual(result1.Value, result2.Value);
-        Assert.AreEqual(result1.Score, result2.Score);
-        Assert.AreEqual(result1.Index, result2.Index);
+        Assert.Equal(result1.Value, result2.Value);
+        Assert.Equal(result1.Score, result2.Score);
+        Assert.Equal(result1.Index, result2.Index);
     }
 
-    [Test]
+    [Fact]
     public void TestSimplifiedSyntax_EquivalentToExplicitSyntax()
     {
         var query = "chicago cubs vs new york mets";
@@ -71,7 +64,7 @@ public class ProcessPipelineTests
         var result2 = pipeline2.ExtractOne(_baseballStrings);
     }
 
-    [Test]
+    [Fact]
     public void TestSimplifiedSyntax_ParallelOnly()
     {
         var query = "atlanta braves vs philadelphia phillies";
@@ -83,11 +76,11 @@ public class ProcessPipelineTests
 
         var result = pipeline.ExtractOne(query, _baseballStrings);
 
-        Assert.IsNotNull(result);
-        Assert.IsNotNull(result.Value);
+        Assert.NotNull(result);
+        Assert.NotNull(result.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestSimplifiedSyntax_CachedOnly()
     {
         var query = "new york mets at chicago cubs";
@@ -99,11 +92,11 @@ public class ProcessPipelineTests
 
         var result = pipeline.ExtractOne(_baseballStrings);
 
-        Assert.IsNotNull(result);
-        Assert.IsNotNull(result.Value);
+        Assert.NotNull(result);
+        Assert.NotNull(result.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestPipelineVsStaticAPI_ExtractOne()
     {
         var query = "philadelphia phillies at atlanta braves";
@@ -113,12 +106,12 @@ public class ProcessPipelineTests
         var pipeline = Process.Configure().Build();
         var pipelineResult = pipeline.ExtractOne(query, _baseballStrings);
 
-        Assert.AreEqual(staticResult.Value, pipelineResult.Value);
-        Assert.AreEqual(staticResult.Score, pipelineResult.Score);
-        Assert.AreEqual(staticResult.Index, pipelineResult.Index);
+        Assert.Equal(staticResult.Value, pipelineResult.Value);
+        Assert.Equal(staticResult.Score, pipelineResult.Score);
+        Assert.Equal(staticResult.Index, pipelineResult.Index);
     }
 
-    [Test]
+    [Fact]
     public void TestPipelineVsStaticAPI_ExtractAll()
     {
         var query = "atlanta braves at philadelphia phillies";
@@ -128,16 +121,16 @@ public class ProcessPipelineTests
         var pipeline = Process.Configure().Build();
         var pipelineResults = pipeline.ExtractAll(query, _baseballStrings).OrderBy(r => r.Index).ToList();
 
-        Assert.AreEqual(staticResults.Count, pipelineResults.Count);
+        Assert.Equal(staticResults.Count, pipelineResults.Count);
         for (int i = 0; i < staticResults.Count; i++)
         {
-            Assert.AreEqual(staticResults[i].Value, pipelineResults[i].Value);
-            Assert.AreEqual(staticResults[i].Score, pipelineResults[i].Score);
-            Assert.AreEqual(staticResults[i].Index, pipelineResults[i].Index);
+            Assert.Equal(staticResults[i].Value, pipelineResults[i].Value);
+            Assert.Equal(staticResults[i].Score, pipelineResults[i].Score);
+            Assert.Equal(staticResults[i].Index, pipelineResults[i].Index);
         }
     }
 
-    [Test]
+    [Fact]
     public void TestPipelineVsStaticAPI_ExtractTop()
     {
         var query = "chicago cubs vs new york mets";
@@ -147,15 +140,15 @@ public class ProcessPipelineTests
         var pipeline = Process.Configure().Build();
         var pipelineResults = pipeline.ExtractTop(query, _baseballStrings, limit: 2).ToList();
 
-        Assert.AreEqual(staticResults.Count, pipelineResults.Count);
+        Assert.Equal(staticResults.Count, pipelineResults.Count);
         for (int i = 0; i < staticResults.Count; i++)
         {
-            Assert.AreEqual(staticResults[i].Value, pipelineResults[i].Value);
-            Assert.AreEqual(staticResults[i].Score, pipelineResults[i].Score);
+            Assert.Equal(staticResults[i].Value, pipelineResults[i].Value);
+            Assert.Equal(staticResults[i].Score, pipelineResults[i].Score);
         }
     }
 
-    [Test]
+    [Fact]
     public void TestCancellationToken_Parallel()
     {
         var longList = Enumerable.Range(0, 10000).Select(i => $"team {i} vs team {i + 1}").ToArray();
@@ -180,7 +173,7 @@ public class ProcessPipelineTests
         });
     }
 
-    [Test]
+    [Fact]
     public void TestCancellationToken_ParallelDuringExecution()
     {
         // Create a large dataset
@@ -209,7 +202,7 @@ public class ProcessPipelineTests
         });
     }
 
-    [Test]
+    [Fact]
     public void TestParallelResultsMatchSequential()
     {
         var query = "new york mets at atlanta braves";
@@ -225,16 +218,16 @@ public class ProcessPipelineTests
         var parallelResults = parallelPipeline.ExtractAll(query, _baseballStrings)
             .OrderBy(r => r.Index).ToList();
 
-        Assert.AreEqual(sequentialResults.Count, parallelResults.Count);
+        Assert.Equal(sequentialResults.Count, parallelResults.Count);
         for (int i = 0; i < sequentialResults.Count; i++)
         {
-            Assert.AreEqual(sequentialResults[i].Value, parallelResults[i].Value);
-            Assert.AreEqual(sequentialResults[i].Score, parallelResults[i].Score);
-            Assert.AreEqual(sequentialResults[i].Index, parallelResults[i].Index);
+            Assert.Equal(sequentialResults[i].Value, parallelResults[i].Value);
+            Assert.Equal(sequentialResults[i].Score, parallelResults[i].Score);
+            Assert.Equal(sequentialResults[i].Index, parallelResults[i].Index);
         }
     }
 
-    [Test]
+    [Fact]
     public void TestCachedWithExternalScorer()
     {
         var query = "new york mets at atlanta braves";
@@ -248,11 +241,11 @@ public class ProcessPipelineTests
         var result1 = pipeline.ExtractOne(_baseballStrings);
         var result2 = pipeline.ExtractOne(_baseballStrings);
 
-        Assert.AreEqual(result1.Value, result2.Value);
-        Assert.AreEqual(result1.Score, result2.Score);
+        Assert.Equal(result1.Value, result2.Value);
+        Assert.Equal(result1.Score, result2.Score);
     }
 
-    [Test]
+    [Fact]
     public void TestCachedParallelWithExternalScorer()
     {
         var query = "chicago cubs vs new york mets";
@@ -266,11 +259,11 @@ public class ProcessPipelineTests
 
         var results = pipeline.ExtractAll(_baseballStrings).OrderBy(r => r.Index).ToList();
 
-        Assert.IsTrue(results.Count > 0);
-        Assert.IsTrue(results.Any(r => r.Score > 50));
+        Assert.True(results.Count > 0);
+        Assert.Contains(results, r => r.Score > 50);
     }
 
-    [Test]
+    [Fact]
     public void TestGenericTypeExtractOne()
     {
         var events = new[]
@@ -286,11 +279,11 @@ public class ProcessPipelineTests
         var pipeline = Process.Configure().Build();
         var pipelineResult = pipeline.ExtractOneBy(query, events, strings => strings[0]);
 
-        Assert.AreEqual(staticResult.Value, pipelineResult.Value);
-        Assert.AreEqual(staticResult.Score, pipelineResult.Score);
+        Assert.Equal(staticResult.Value, pipelineResult.Value);
+        Assert.Equal(staticResult.Score, pipelineResult.Score);
     }
 
-    [Test]
+    [Fact]
     public void TestGenericTypeExtractOne_Parallel()
     {
         var events = new[]
@@ -307,11 +300,11 @@ public class ProcessPipelineTests
         var sequentialResult = sequentialPipeline.ExtractOneBy(query, events, strings => strings[0]);
         var parallelResult = parallelPipeline.ExtractOneBy(query, events, strings => strings[0]);
 
-        Assert.AreEqual(sequentialResult.Value, parallelResult.Value);
-        Assert.AreEqual(sequentialResult.Score, parallelResult.Score);
+        Assert.Equal(sequentialResult.Value, parallelResult.Value);
+        Assert.Equal(sequentialResult.Score, parallelResult.Score);
     }
 
-    [Test]
+    [Fact]
     public void TestExtractSorted()
     {
         var query = "new york mets at atlanta braves";
@@ -321,15 +314,15 @@ public class ProcessPipelineTests
         var pipeline = Process.Configure().Build();
         var pipelineResults = pipeline.ExtractSorted(query, _baseballStrings).ToList();
 
-        Assert.AreEqual(staticResults.Count, pipelineResults.Count);
+        Assert.Equal(staticResults.Count, pipelineResults.Count);
         for (int i = 0; i < staticResults.Count; i++)
         {
-            Assert.AreEqual(staticResults[i].Value, pipelineResults[i].Value);
-            Assert.AreEqual(staticResults[i].Score, pipelineResults[i].Score);
+            Assert.Equal(staticResults[i].Value, pipelineResults[i].Value);
+            Assert.Equal(staticResults[i].Score, pipelineResults[i].Score);
         }
     }
 
-    [Test]
+    [Fact]
     public void TestExtractSorted_Parallel()
     {
         var query = "new york mets at atlanta braves";
@@ -340,15 +333,15 @@ public class ProcessPipelineTests
         var sequentialResults = sequentialPipeline.ExtractSorted(query, _baseballStrings).ToList();
         var parallelResults = parallelPipeline.ExtractSorted(query, _baseballStrings).ToList();
 
-        Assert.AreEqual(sequentialResults.Count, parallelResults.Count);
+        Assert.Equal(sequentialResults.Count, parallelResults.Count);
         for (int i = 0; i < sequentialResults.Count; i++)
         {
-            Assert.AreEqual(sequentialResults[i].Value, parallelResults[i].Value);
-            Assert.AreEqual(sequentialResults[i].Score, parallelResults[i].Score);
+            Assert.Equal(sequentialResults[i].Value, parallelResults[i].Value);
+            Assert.Equal(sequentialResults[i].Score, parallelResults[i].Score);
         }
     }
 
-    [Test]
+    [Fact]
     public void TestMultiplePipelinesReusable()
     {
         var query1 = "new york mets at atlanta braves";
@@ -362,8 +355,9 @@ public class ProcessPipelineTests
         var result1 = pipeline.ExtractOne(query1, _baseballStrings);
         var result2 = pipeline.ExtractOne(query2, _baseballStrings);
 
-        Assert.IsNotNull(result1);
-        Assert.IsNotNull(result2);
-        Assert.AreNotEqual(result1.Value, result2.Value);
+        Assert.NotNull(result1);
+        Assert.NotNull(result2);
+        Assert.NotEqual(result1.Value, result2.Value);
     }
 }
+

--- a/FuzzySharp.Test/FuzzyTests/ProcessStringQueryGenericChoicesTests.cs
+++ b/FuzzySharp.Test/FuzzyTests/ProcessStringQueryGenericChoicesTests.cs
@@ -1,5 +1,5 @@
-﻿using System.Linq;
-using NUnit.Framework;
+using System.Linq;
+using Xunit;
 
 namespace Raffinert.FuzzySharp.Test.FuzzyTests;
 
@@ -12,7 +12,6 @@ namespace Raffinert.FuzzySharp.Test.FuzzyTests;
 /// <see cref="Process.ExtractOneBy{T}(string, System.Collections.Generic.IEnumerable{T}, System.Func{T,string}, Raffinert.FuzzySharp.SimilarityRatio.Scorer.IRatioScorer, int)"/>,
 /// as well as the equivalent <see cref="ProcessPipeline"/> methods.
 /// </summary>
-[TestFixture]
 public class ProcessStringQueryGenericChoicesTests
 {
     private class Event
@@ -23,148 +22,140 @@ public class ProcessStringQueryGenericChoicesTests
         public override string ToString() => $"{Name} @ {Venue}";
     }
 
-    private Event[] _events;
-    private string _query;
-
-    [SetUp]
-    public void Setup()
+    private readonly Event[] _events = new[]
     {
-        _events = new[]
-        {
-            new Event("new york mets vs chicago cubs", "CitiField"),
-            new Event("chicago cubs vs chicago white sox", "Wrigley Field"),
-            new Event("philadelphia phillies vs atlanta braves", "Citizens Bank Park"),
-            new Event("braves vs mets", "Turner Field"),
-        };
-
-        _query = "new york mets at chicago cubs";
-    }
+        new Event("new york mets vs chicago cubs", "CitiField"),
+        new Event("chicago cubs vs chicago white sox", "Wrigley Field"),
+        new Event("philadelphia phillies vs atlanta braves", "Citizens Bank Park"),
+        new Event("braves vs mets", "Turner Field"),
+    };
+    private readonly string _query = "new york mets at chicago cubs";
 
     // -------------------------------------------------------------------------
     // Process.ExtractAll<T>(string query, ...)
     // -------------------------------------------------------------------------
 
-    [Test]
+    [Fact]
     public void ExtractAllBy_StringQuery_GenericChoices_ReturnsAllAboveCutoff()
     {
         var results = Process.ExtractAllBy(_query, _events, e => e.Name, cutoff: 50).ToList();
 
-        Assert.IsNotEmpty(results);
-        Assert.IsTrue(results.All(r => r.Score >= 50));
+        Assert.NotEmpty(results);
+        Assert.True(results.All(r => r.Score >= 50));
     }
 
-    [Test]
+    [Fact]
     public void ExtractAllBy_StringQuery_GenericChoices_NoCutoff_ReturnsAllChoices()
     {
         var results = Process.ExtractAllBy(_query, _events, e => e.Name).ToList();
 
-        Assert.AreEqual(_events.Length, results.Count);
+        Assert.Equal(_events.Length, results.Count);
     }
 
-    [Test]
+    [Fact]
     public void ExtractAllBy_StringQuery_GenericChoices_BestMatchIsCorrect()
     {
         var results = Process.ExtractAllBy(_query, _events, e => e.Name).ToList();
         var best = results.OrderByDescending(r => r.Score).First();
 
-        Assert.AreEqual(_events[0], best.Value);
+        Assert.Equal(_events[0], best.Value);
     }
 
     // -------------------------------------------------------------------------
     // Process.ExtractTop<T>(string query, ...)
     // -------------------------------------------------------------------------
 
-    [Test]
+    [Fact]
     public void ExtractTopBy_StringQuery_GenericChoices_RespectsLimit()
     {
         var results = Process.ExtractTopBy(_query, _events, e => e.Name, limit: 2).ToList();
 
-        Assert.AreEqual(2, results.Count);
+        Assert.Equal(2, results.Count);
     }
 
-    [Test]
+    [Fact]
     public void ExtractTopBy_StringQuery_GenericChoices_ResultsAreSortedDescending()
     {
         var results = Process.ExtractTopBy(_query, _events, e => e.Name, limit: 3).ToList();
 
         for (int i = 1; i < results.Count; i++)
         {
-            Assert.GreaterOrEqual(results[i - 1].Score, results[i].Score);
+            Assert.True(results[i - 1].Score >= results[i].Score);
         }
     }
 
-    [Test]
+    [Fact]
     public void ExtractTopBy_StringQuery_GenericChoices_BestMatchIsCorrect()
     {
         var results = Process.ExtractTopBy(_query, _events, e => e.Name, limit: 1).ToList();
 
-        Assert.AreEqual(_events[0], results[0].Value);
+        Assert.Equal(_events[0], results[0].Value);
     }
 
     // -------------------------------------------------------------------------
     // Process.ExtractSorted<T>(string query, ...)
     // -------------------------------------------------------------------------
 
-    [Test]
+    [Fact]
     public void ExtractSortedBy_StringQuery_GenericChoices_ResultsAreSortedDescending()
     {
         var results = Process.ExtractSortedBy(_query, _events, e => e.Name).ToList();
 
         for (int i = 1; i < results.Count; i++)
         {
-            Assert.GreaterOrEqual(results[i - 1].Score, results[i].Score);
+            Assert.True(results[i - 1].Score >= results[i].Score);
         }
     }
 
-    [Test]
+    [Fact]
     public void ExtractSortedBy_StringQuery_GenericChoices_BestMatchIsFirst()
     {
         var results = Process.ExtractSortedBy(_query, _events, e => e.Name).ToList();
 
-        Assert.AreEqual(_events[0], results[0].Value);
+        Assert.Equal(_events[0], results[0].Value);
     }
 
-    [Test]
+    [Fact]
     public void ExtractSortedBy_StringQuery_GenericChoices_CutoffFiltersResults()
     {
         var results = Process.ExtractSortedBy("zzzzzz completely unrelated", _events, e => e.Name, cutoff: 90).ToList();
 
-        Assert.IsEmpty(results);
+        Assert.Empty(results);
     }
 
     // -------------------------------------------------------------------------
     // Process.ExtractOne<T>(string query, ...)
     // -------------------------------------------------------------------------
 
-    [Test]
+    [Fact]
     public void ExtractOneBy_StringQuery_GenericChoices_ReturnsBestMatch()
     {
         var result = Process.ExtractOneBy(_query, _events, e => e.Name);
 
-        Assert.AreEqual(_events[0], result.Value);
+        Assert.Equal(_events[0], result.Value);
     }
 
-    [Test]
+    [Fact]
     public void ExtractOneBy_StringQuery_GenericChoices_IndexIsCorrect()
     {
         var result = Process.ExtractOneBy(_query, _events, e => e.Name);
 
-        Assert.AreEqual(0, result.Index);
+        Assert.Equal(0, result.Index);
     }
 
-    [Test]
+    [Fact]
     public void ExtractOneBy_StringQuery_GenericChoices_ScoreIsPositive()
     {
         var result = Process.ExtractOneBy(_query, _events, e => e.Name);
 
-        Assert.Greater(result.Score, 0);
+        Assert.True(result.Score > 0);
     }
 
     // -------------------------------------------------------------------------
     // ProcessPipeline equivalents (via Process.Configure())
     // -------------------------------------------------------------------------
 
-    [Test]
+    [Fact]
     public void Pipeline_ExtractAllBy_StringQuery_GenericChoices_MatchesProcess()
     {
         var pipeline = Process.Configure().Build();
@@ -172,15 +163,15 @@ public class ProcessStringQueryGenericChoicesTests
         var direct   = Process.ExtractAllBy(_query, _events, e => e.Name).OrderBy(r => r.Index).ToList();
         var piped    = pipeline.ExtractAllBy(_query, _events, e => e.Name).OrderBy(r => r.Index).ToList();
 
-        Assert.AreEqual(direct.Count, piped.Count);
+        Assert.Equal(direct.Count, piped.Count);
         for (int i = 0; i < direct.Count; i++)
         {
-            Assert.AreEqual(direct[i].Value, piped[i].Value);
-            Assert.AreEqual(direct[i].Score, piped[i].Score);
+            Assert.Equal(direct[i].Value, piped[i].Value);
+            Assert.Equal(direct[i].Score, piped[i].Score);
         }
     }
 
-    [Test]
+    [Fact]
     public void Pipeline_ExtractTopBy_StringQuery_GenericChoices_MatchesProcess()
     {
         var pipeline = Process.Configure().Build();
@@ -188,14 +179,14 @@ public class ProcessStringQueryGenericChoicesTests
         var direct = Process.ExtractTopBy(_query, _events, e => e.Name, limit: 2).ToList();
         var piped  = pipeline.ExtractTopBy(_query, _events, e => e.Name, limit: 2).ToList();
 
-        Assert.AreEqual(direct.Count, piped.Count);
+        Assert.Equal(direct.Count, piped.Count);
         for (int i = 0; i < direct.Count; i++)
         {
-            Assert.AreEqual(direct[i].Value, piped[i].Value);
+            Assert.Equal(direct[i].Value, piped[i].Value);
         }
     }
 
-    [Test]
+    [Fact]
     public void Pipeline_ExtractOneBy_StringQuery_GenericChoices_MatchesProcess()
     {
         var pipeline = Process.Configure().Build();
@@ -203,7 +194,8 @@ public class ProcessStringQueryGenericChoicesTests
         var direct = Process.ExtractOneBy(_query, _events, e => e.Name);
         var piped  = pipeline.ExtractOneBy(_query, _events, e => e.Name);
 
-        Assert.AreEqual(direct.Value, piped.Value);
-        Assert.AreEqual(direct.Score, piped.Score);
+        Assert.Equal(direct.Value, piped.Value);
+        Assert.Equal(direct.Score, piped.Score);
     }
 }
+

--- a/FuzzySharp.Test/FuzzyTests/ProcessTests.cs
+++ b/FuzzySharp.Test/FuzzyTests/ProcessTests.cs
@@ -1,12 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
+using Xunit;
 using Raffinert.FuzzySharp.SimilarityRatio;
 using Raffinert.FuzzySharp.SimilarityRatio.Scorer.StrategySensitive;
 
 namespace Raffinert.FuzzySharp.Test.FuzzyTests;
 
-[TestFixture]
 public class ProcessTests
 {
     private string   _s1;
@@ -19,16 +18,15 @@ public class ProcessTests
     private string[] _cirqueStrings;
     private string[] _baseballStrings;
 
-    [SetUp]
-    public void Setup()
+    public ProcessTests()
     {
-        _s1  = "new york mets";
+        _s1 = "new york mets";
         _s1A = "new york mets";
-        _s2  = "new YORK mets";
-        _s3  = "the wonderful new york mets";
-        _s4  = "new york mets vs atlanta braves";
-        _s5  = "atlanta braves vs new york mets";
-        _s6  = "new york mets - atlanta braves";
+        _s2 = "new YORK mets";
+        _s3 = "the wonderful new york mets";
+        _s4 = "new york mets vs atlanta braves";
+        _s5 = "atlanta braves vs new york mets";
+        _s6 = "new york mets - atlanta braves";
         _cirqueStrings = new[]
         {
             "cirque du soleil - zarkana - las vegas",
@@ -48,43 +46,43 @@ public class ProcessTests
         };
     }
 
-    [Test]
+    [Fact]
     public void TestGetBestChoice1()
     {
         var query = "new york mets at atlanta braves";
         var best  = Process.ExtractOne(query, _baseballStrings);
-        Assert.AreEqual(best.Value, "braves vs mets");
+        Assert.Equal(best.Value, "braves vs mets");
 
     }
 
-    [Test]
+    [Fact]
     public void TestGetBestChoice2()
     {
         var query = "philadelphia phillies at atlanta braves";
         var best  = Process.ExtractOne(query, _baseballStrings);
-        Assert.AreEqual(best.Value, _baseballStrings[2]);
+        Assert.Equal(best.Value, _baseballStrings[2]);
 
     }
 
-    [Test]
+    [Fact]
     public void TestGetBestChoice3()
     {
         var query = "atlanta braves at philadelphia phillies";
         var best  = Process.ExtractOne(query, _baseballStrings);
-        Assert.AreEqual(best.Value, _baseballStrings[2]);
+        Assert.Equal(best.Value, _baseballStrings[2]);
 
     }
 
-    [Test]
+    [Fact]
     public void TestGetBestChoice4()
     {
         var query = "chicago cubs vs new york mets";
         var best  = Process.ExtractOne(query, _baseballStrings);
-        Assert.AreEqual(best.Value, _baseballStrings[0]);
+        Assert.Equal(best.Value, _baseballStrings[0]);
 
     }
 
-    [Test]
+    [Fact]
     public void TestWithProcessor()
     {
         var events = new[]
@@ -96,10 +94,10 @@ public class ProcessTests
         var query = new[] { "new york mets vs chicago cubs", "CitiField", "2017-03-19", "8pm" };
 
         var best = Process.ExtractOneBy(query, events, strings => strings[0]);
-        Assert.AreEqual(best.Value, events[0]);
+        Assert.Equal(best.Value, events[0]);
     }
 
-    [Test]
+    [Fact]
     public void TestWithScorer()
     {
         var choices = new[]
@@ -125,19 +123,19 @@ public class ProcessTests
         // 'complete' match of choices[1]"
 
         var best = Process.ExtractOne(query, choices);
-        Assert.AreEqual(best.Value, choices[1]);
+        Assert.Equal(best.Value, choices[1]);
 
         // now, use the custom scorer
 
         best = Process.ExtractOne(query, choices, null, ScorerCache.Get<DefaultRatioScorer>());
-        Assert.AreEqual(best.Value, choices[0]);
+        Assert.Equal(best.Value, choices[0]);
 
         best = Process.ExtractOne(query, choicesDict.Select(k => k.Value));
-        Assert.AreEqual(best.Value, choicesDict[1]);
+        Assert.Equal(best.Value, choicesDict[1]);
 
     }
 
-    [Test]
+    [Fact]
     public void TestWithCutoff()
     {
         var choices = new[]
@@ -154,7 +152,7 @@ public class ProcessTests
         // we don't want to randomly match to something, so we use a reasonable cutoff
 
         var best = Process.ExtractSorted(query, choices, cutoff: 50);
-        Assert.IsTrue(!best.Any());
+        Assert.True(!best.Any());
         // .assertIsNone(best) // unittest.TestCase did not have assertIsNone until Python 2.7
 
         // however if we had no cutoff, something would get returned
@@ -164,7 +162,7 @@ public class ProcessTests
 
     }
 
-    [Test]
+    [Fact]
     public void TestWithCutoff2()
     {
         var choices = new[]
@@ -178,13 +176,13 @@ public class ProcessTests
         var query = "new york mets vs chicago cubs";
         // Only find 100-score cases
         var res = Process.ExtractSorted(query, choices, cutoff: 100);
-        Assert.IsTrue(res.Any());
+        Assert.True(res.Any());
         var bestMatch = res.First();
-        Assert.IsTrue(bestMatch.Value == choices[0]);
+        Assert.True(bestMatch.Value == choices[0]);
 
     }
 
-    [Test]
+    [Fact]
     public void TestEmptyStrings()
     {
         var choices = new[]
@@ -199,10 +197,10 @@ public class ProcessTests
         var query = "new york mets at chicago cubs";
 
         var best = Process.ExtractOne(query, choices);
-        Assert.AreEqual(best.Value, choices[1]);
+        Assert.Equal(best.Value, choices[1]);
     }
 
-//[Test]
+//[Fact]
 //public void  generate_choices() {
 //            choices = ['a', 'Bb', 'CcC']
 //            for choice in choices {
@@ -214,7 +212,7 @@ public class ProcessTests
 
 //    }
 
-//[Test]
+//[Fact]
 //public void  test_dict_like_Extract() {
 //        """We should be able to use a dict-like object for choices, not only a
 //        dict, and still get dict-like output.
@@ -232,7 +230,7 @@ public class ProcessTests
 
 //    }
 
-//[Test]
+//[Fact]
 //public void  test_dedupe() {
 //        """We should be able to use a list-like object for contains_dupes
 //        """
@@ -249,11 +247,11 @@ public class ProcessTests
 //        deduped_list = ['Tom', 'Dick', 'Harry']
 
 //        result = Process.dedupe(contains_dupes)
-//        Assert.AreEqual(result, deduped_list)
+//        Assert.Equal(result, deduped_list)
 
 //    }
 
-//[Test]
+//[Fact]
 //public void  test_simplematch() {
 //        basic_string = 'a, b'
 //        match_strings = ['a, b']
@@ -261,8 +259,9 @@ public class ProcessTests
 //        result = Process.ExtractOne(basic_string, match_strings, scorer=fuzz.ratio)
 //        part_result = Process.ExtractOne(basic_string, match_strings, scorer=fuzz.partial_ratio)
 
-//        Assert.AreEqual(result, ('a, b', 100))
-//        Assert.AreEqual(part_result, ('a, b', 100))
+//        Assert.Equal(result, ('a, b', 100))
+//        Assert.Equal(part_result, ('a, b', 100))
 
 //    }
 }
+

--- a/FuzzySharp.Test/FuzzyTests/RatioIssuesTests.cs
+++ b/FuzzySharp.Test/FuzzyTests/RatioIssuesTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using Xunit;
 using Raffinert.FuzzySharp.SimilarityRatio.Strategy.Generic;
 using System;
 
@@ -7,28 +7,28 @@ namespace Raffinert.FuzzySharp.Test.FuzzyTests;
 // Original code https://github.com/rapidfuzz/RapidFuzz/blob/main/tests/test_fuzz.py
 public class RatioIssuesTests
 {
-    [Test]
+    [Fact]
     public void Issue76()
     {
-        Assert.That(Fuzz.PartialRatio("physics 2 vid", "study physics physics 2"), Is.EqualTo(82));
-        Assert.That(Fuzz.PartialRatio("physics 2 vid", "study physics physics 2 video"), Is.EqualTo(100));
+        Assert.Equal(82, Fuzz.PartialRatio("physics 2 vid", "study physics physics 2"));
+        Assert.Equal(100, Fuzz.PartialRatio("physics 2 vid", "study physics physics 2 video"));
     }
 
-    [Test]
+    [Fact]
     public void Issue90()
     {
-        Assert.That(Fuzz.PartialRatio("ax b", "a b a c b"), Is.EqualTo(86));
+        Assert.Equal(86, Fuzz.PartialRatio("ax b", "a b a c b"));
     }
 
-    [Test]
+    [Fact]
     public void Issue138()
     {
         var str1 = new string('a', 65);
         var str2 = "a" + (char)256 + new string('a', 63);
-        Assert.That(Fuzz.PartialRatio(str1, str2), Is.EqualTo(99));
+        Assert.Equal(99, Fuzz.PartialRatio(str1, str2));
     }
 
-    [Test]
+    [Fact]
     public void PartialRatioAlignment()
     {
         var a = "a certain string".AsSpan();
@@ -36,31 +36,31 @@ public class RatioIssuesTests
 
         var align1 = PartialRatioStrategy<char>.PartialRatioAlignment(s, a);
 
-        Assert.That(align1.Score, Is.EqualTo(100));
-        Assert.That(align1.SrcStart, Is.EqualTo(0));
-        Assert.That(align1.SrcEnd, Is.EqualTo(s.Length));
-        Assert.That(align1.DestStart, Is.EqualTo(2));
-        Assert.That(align1.DestEnd, Is.EqualTo(2 + s.Length));
+        Assert.Equal(100, align1.Score);
+        Assert.Equal(0, align1.SrcStart);
+        Assert.Equal(s.Length, align1.SrcEnd);
+        Assert.Equal(2, align1.DestStart);
+        Assert.Equal(2 + s.Length, align1.DestEnd);
 
         var align2 = PartialRatioStrategy<char>.PartialRatioAlignment(a, s);
-        Assert.That(align2.Score, Is.EqualTo(100));
-        Assert.That(align2.SrcStart, Is.EqualTo(2));
-        Assert.That(align2.SrcEnd, Is.EqualTo(2 + s.Length));
-        Assert.That(align2.DestStart, Is.EqualTo(0));
-        Assert.That(align2.DestEnd, Is.EqualTo(s.Length));
+        Assert.Equal(100, align2.Score);
+        Assert.Equal(2, align2.SrcStart);
+        Assert.Equal(2 + s.Length, align2.SrcEnd);
+        Assert.Equal(0, align2.DestStart);
+        Assert.Equal(s.Length, align2.DestEnd);
 
-        Assert.That(PartialRatioStrategy<char>.PartialRatioAlignment(null, "test".AsSpan()).Score, Is.EqualTo(0));
-        Assert.That(PartialRatioStrategy<char>.PartialRatioAlignment("test".AsSpan(), null).Score, Is.EqualTo(0));
-        Assert.That(PartialRatioStrategy<char>.PartialRatioAlignment("test".AsSpan(), "tesx".AsSpan(), scoreCutoff: 90).Score, Is.EqualTo(0));
+        Assert.Equal(0, PartialRatioStrategy<char>.PartialRatioAlignment(null, "test".AsSpan()).Score);
+        Assert.Equal(0, PartialRatioStrategy<char>.PartialRatioAlignment("test".AsSpan(), null).Score);
+        Assert.Equal(0, PartialRatioStrategy<char>.PartialRatioAlignment("test".AsSpan(), "tesx".AsSpan(), scoreCutoff: 90).Score);
     }
 
-    [Test]
+    [Fact]
     public void Issue196()
     {
-        Assert.That(Fuzz.WeightedRatio("South Korea", "North Korea"), Is.EqualTo(82));
+        Assert.Equal(82, Fuzz.WeightedRatio("South Korea", "North Korea"));
     }
 
-    [Test]
+    [Fact]
     public void Issue231()
     {
         var str1 = "er merkantilismus förderte handle und verkehr mit teils marktkonformen, teils dirigistischen maßnahmen.";
@@ -68,10 +68,11 @@ public class RatioIssuesTests
 
         var alignment = PartialRatioStrategy<char>.PartialRatioAlignment(str1.AsSpan(), str2.AsSpan());
 
-        Assert.That(alignment, Is.Not.Null);
-        Assert.That(alignment.SrcStart, Is.EqualTo(0));
-        Assert.That(alignment.SrcEnd, Is.EqualTo(103));
-        Assert.That(alignment.DestStart, Is.EqualTo(0));
-        Assert.That(alignment.DestEnd, Is.EqualTo(51));
+        Assert.NotNull(alignment);
+        Assert.Equal(0, alignment.SrcStart);
+        Assert.Equal(103, alignment.SrcEnd);
+        Assert.Equal(0, alignment.DestStart);
+        Assert.Equal(51, alignment.DestEnd);
     }
 }
+

--- a/FuzzySharp.Test/FuzzyTests/RatioTests.cs
+++ b/FuzzySharp.Test/FuzzyTests/RatioTests.cs
@@ -1,9 +1,8 @@
-using NUnit.Framework;
+using Xunit;
 using Raffinert.FuzzySharp.PreProcess;
 
 namespace Raffinert.FuzzySharp.Test.FuzzyTests;
 
-[TestFixture]
 public class RatioTests
 {
     #region Private Fields
@@ -25,8 +24,7 @@ public class RatioTests
     private string[] _cirqueStrings, _baseballStrings;
     #endregion
 
-    [SetUp]
-    public void Setup()
+    public RatioTests()
     {
         _s1  = "new york mets";
         _s1A = "new york mets";
@@ -45,105 +43,105 @@ public class RatioTests
         _s10A = "{b";
     }
 
-    [Test]
+    [Fact]
     public void Test_Equal()
     {
-        Assert.AreEqual(Fuzz.Ratio(_s1, _s1A), 100);
-        Assert.AreEqual(Fuzz.Ratio(_s8, _s8A), 100);
-        Assert.AreEqual(Fuzz.Ratio(_s9, _s9A), 100);
+        Assert.Equal(Fuzz.Ratio(_s1, _s1A), 100);
+        Assert.Equal(Fuzz.Ratio(_s8, _s8A), 100);
+        Assert.Equal(Fuzz.Ratio(_s9, _s9A), 100);
     }
 
-    [Test]
+    [Fact]
     public void Test_Case_Insensitive()
     {
-        Assert.AreNotEqual(Fuzz.Ratio(_s1, _s2), 100);
-        Assert.AreEqual(Fuzz.Ratio(_s1, _s2, StringPreprocessor.Full), 100);
+        Assert.NotEqual(Fuzz.Ratio(_s1, _s2), 100);
+        Assert.Equal(Fuzz.Ratio(_s1, _s2, StringPreprocessor.Full), 100);
     }
 
-    [Test]
+    [Fact]
     public void Test_Partial()
     {
-        Assert.AreEqual(Fuzz.PartialRatio(_s1, _s3), 100);
+        Assert.Equal(Fuzz.PartialRatio(_s1, _s3), 100);
     }
 
-    [Test]
+    [Fact]
     public void TestTokenSortRatio()
     {
-        Assert.AreEqual(Fuzz.TokenSortRatio(_s1, _s1A), 100);
+        Assert.Equal(Fuzz.TokenSortRatio(_s1, _s1A), 100);
     }
 
-    [Test]
+    [Fact]
     public void TestPartialTokenSortRatio()
     {
-        Assert.AreEqual(Fuzz.PartialTokenSortRatio(_s1, _s1A, StringPreprocessor.Full), 100);
-        Assert.AreEqual(Fuzz.PartialTokenSortRatio(_s4, _s5, StringPreprocessor.Full), 100);
-        Assert.AreEqual(Fuzz.PartialTokenSortRatio(_s8, _s8A), 100);
-        Assert.AreEqual(Fuzz.PartialTokenSortRatio(_s9, _s9A, StringPreprocessor.Full), 100);
-        Assert.AreEqual(Fuzz.PartialTokenSortRatio(_s9, _s9A), 100);
+        Assert.Equal(Fuzz.PartialTokenSortRatio(_s1, _s1A, StringPreprocessor.Full), 100);
+        Assert.Equal(Fuzz.PartialTokenSortRatio(_s4, _s5, StringPreprocessor.Full), 100);
+        Assert.Equal(Fuzz.PartialTokenSortRatio(_s8, _s8A), 100);
+        Assert.Equal(Fuzz.PartialTokenSortRatio(_s9, _s9A, StringPreprocessor.Full), 100);
+        Assert.Equal(Fuzz.PartialTokenSortRatio(_s9, _s9A), 100);
 
         //var al =  Fuzz1.PartialRatioAlignment("a certain string".AsSpan(), "cetain".AsSpan());
             
-        Assert.AreEqual(Fuzz.PartialTokenSortRatio(_s10, _s10A), 67);
-        Assert.AreEqual(Fuzz.PartialTokenSortRatio(_s10, _s10A, StringPreprocessor.Full), 0);
+        Assert.Equal(Fuzz.PartialTokenSortRatio(_s10, _s10A), 67);
+        Assert.Equal(Fuzz.PartialTokenSortRatio(_s10, _s10A, StringPreprocessor.Full), 0);
     }
 
-    [Test]
+    [Fact]
     public void TestTokenSetRatio()
     {
-        Assert.AreEqual(Fuzz.TokenSetRatio(_s4, _s5, StringPreprocessor.Full), 100);
-        Assert.AreEqual(Fuzz.TokenSetRatio(_s8, _s8A), 100);
-        Assert.AreEqual(Fuzz.TokenSetRatio(_s9, _s9A, StringPreprocessor.Full), 100);
-        Assert.AreEqual(Fuzz.TokenSetRatio(_s9, _s9A), 100);
-        Assert.AreEqual(Fuzz.TokenSetRatio(_s10, _s10A), 50);
+        Assert.Equal(Fuzz.TokenSetRatio(_s4, _s5, StringPreprocessor.Full), 100);
+        Assert.Equal(Fuzz.TokenSetRatio(_s8, _s8A), 100);
+        Assert.Equal(Fuzz.TokenSetRatio(_s9, _s9A, StringPreprocessor.Full), 100);
+        Assert.Equal(Fuzz.TokenSetRatio(_s9, _s9A), 100);
+        Assert.Equal(Fuzz.TokenSetRatio(_s10, _s10A), 50);
     }
 
-    [Test]
+    [Fact]
     public void TestTokenAbbreviationRatio()
     {
-        Assert.AreEqual(Fuzz.TokenAbbreviationRatio("bl 420", "Baseline section 420", StringPreprocessor.Full), 40);
-        Assert.AreEqual(Fuzz.PartialTokenAbbreviationRatio("bl 420", "Baseline section 420", StringPreprocessor.Full), 67);
+        Assert.Equal(Fuzz.TokenAbbreviationRatio("bl 420", "Baseline section 420", StringPreprocessor.Full), 40);
+        Assert.Equal(Fuzz.PartialTokenAbbreviationRatio("bl 420", "Baseline section 420", StringPreprocessor.Full), 67);
     }
 
-    [Test]
+    [Fact]
     public void TestPartialTokenSetRatio()
     {
-        Assert.AreEqual(Fuzz.PartialTokenSetRatio(_s4, _s7), 100);
+        Assert.Equal(Fuzz.PartialTokenSetRatio(_s4, _s7), 100);
     }
 
-    [Test]
+    [Fact]
     public void TestWeightedRatioEqual()
     {
-        Assert.AreEqual(Fuzz.WeightedRatio(_s1, _s1A), 100);
+        Assert.Equal(Fuzz.WeightedRatio(_s1, _s1A), 100);
     }
 
-    [Test]
+    [Fact]
     public void TestWeightedRatioCaseInsensitive()
     {
-        Assert.AreEqual(Fuzz.WeightedRatio(_s1, _s2, StringPreprocessor.Full), 100);
+        Assert.Equal(Fuzz.WeightedRatio(_s1, _s2, StringPreprocessor.Full), 100);
     }
 
-    [Test]
+    [Fact]
     public void TestWeightedRatioPartialMatch()
     {
-        Assert.AreEqual(Fuzz.WeightedRatio(_s1, _s3), 90);
+        Assert.Equal(Fuzz.WeightedRatio(_s1, _s3), 90);
     }
 
-    [Test]
+    [Fact]
     public void TestWeightedRatioMisorderedMatch()
     {
-        Assert.AreEqual(Fuzz.WeightedRatio(_s4, _s5), 95);
+        Assert.Equal(Fuzz.WeightedRatio(_s4, _s5), 95);
     }
 
-    [Test]
+    [Fact]
     public void TestEmptyStringsScore0()
     {
-        Assert.That(Fuzz.Ratio("test_string", ""), Is.EqualTo(0));
-        Assert.That(Fuzz.PartialRatio("test_string", ""), Is.EqualTo(0));
-        Assert.That(Fuzz.Ratio("", ""), Is.EqualTo(0));
-        Assert.That(Fuzz.PartialRatio("", ""), Is.EqualTo(0));
+        Assert.Equal(0, Fuzz.Ratio("test_string", ""));
+        Assert.Equal(0, Fuzz.PartialRatio("test_string", ""));
+        Assert.Equal(0, Fuzz.Ratio("", ""));
+        Assert.Equal(0, Fuzz.PartialRatio("", ""));
     }
 
-    [Test]
+    [Fact]
     public void TestIssueSeven()
     {
         _s1 = "HSINCHUANG";
@@ -151,47 +149,47 @@ public class RatioTests
         _s3 = "LSINJHUANG DISTRIC";
         _s4 = "SINJHUANG DISTRICT";
 
-        Assert.IsTrue(Fuzz.PartialRatio(_s1, _s2) > 75);
-        Assert.IsTrue(Fuzz.PartialRatio(_s1, _s3) > 75);
-        Assert.IsTrue(Fuzz.PartialRatio(_s1, _s4) > 75);
+        Assert.True(Fuzz.PartialRatio(_s1, _s2) > 75);
+        Assert.True(Fuzz.PartialRatio(_s1, _s3) > 75);
+        Assert.True(Fuzz.PartialRatio(_s1, _s4) > 75);
     }
 
-    [Test]
+    [Fact]
     public void TestIssueEight()
     {
         // https://github.com/JakeBayer/FuzzySharp/issues/8
-        Assert.AreEqual(100, Fuzz.PartialRatio("Partnernummer", "Partne\nrnum\nmerASDFPartnernummerASDF")); // was 85 
-        Assert.AreEqual(100, Fuzz.PartialRatio("Partnernummer", "PartnerrrrnummerASDFPartnernummerASDF"));  // was 77
+        Assert.Equal(100, Fuzz.PartialRatio("Partnernummer", "Partne\nrnum\nmerASDFPartnernummerASDF")); // was 85 
+        Assert.Equal(100, Fuzz.PartialRatio("Partnernummer", "PartnerrrrnummerASDFPartnernummerASDF"));  // was 77
 
         // https://github.com/xdrop/fuzzywuzzy/issues/39
-        Assert.AreEqual(100, Fuzz.PartialRatio("kaution", "kdeffxxxiban:de1110010060046666666datum:16.11.17zeit:01:12uft0000899999tan076601testd.-20-maisonette-z4-jobas-hagkautionauszug")); // was 57
+        Assert.Equal(100, Fuzz.PartialRatio("kaution", "kdeffxxxiban:de1110010060046666666datum:16.11.17zeit:01:12uft0000899999tan076601testd.-20-maisonette-z4-jobas-hagkautionauszug")); // was 57
 
         // https://github.com/seatgeek/fuzzywuzzy/issues/79
-        Assert.AreEqual(100, Fuzz.PartialRatio("this is a test", "is this is a not really thing this is a test!")); // was 92 (actually 93)
+        Assert.Equal(100, Fuzz.PartialRatio("this is a test", "is this is a not really thing this is a test!")); // was 92 (actually 93)
 
         // https://github.com/Raffinert/FuzzySharp/issues/2
-        Assert.AreEqual(100, Fuzz.PartialRatio("sh", "Growing eshops without a popular platform", StringPreprocessor.Full));
-        Assert.AreEqual(100, Fuzz.PartialRatio("shop", "Growing eshops without a popular platform", StringPreprocessor.Full));
+        Assert.Equal(100, Fuzz.PartialRatio("sh", "Growing eshops without a popular platform", StringPreprocessor.Full));
+        Assert.Equal(100, Fuzz.PartialRatio("shop", "Growing eshops without a popular platform", StringPreprocessor.Full));
     }
 
-    [Test]
+    [Fact]
     public void MorePartialRatio()
     {
-        Assert.AreEqual(100, Fuzz.PartialRatio("geeks for geeks", "geeks for geeks!"));
-        Assert.AreEqual(71, Fuzz.PartialRatio("geeks for geeks", "geeks geeks"));
-        Assert.AreEqual(100, Fuzz.TokenSortRatio("geeks for geeks", "for geeks geeks"));
+        Assert.Equal(100, Fuzz.PartialRatio("geeks for geeks", "geeks for geeks!"));
+        Assert.Equal(71, Fuzz.PartialRatio("geeks for geeks", "geeks geeks"));
+        Assert.Equal(100, Fuzz.TokenSortRatio("geeks for geeks", "for geeks geeks"));
     }
 
-    [Test]
+    [Fact]
     public void TestPartialRatioUnicodeString()
     {
         _s1 = "\u00C1";
         _s2 = "ABCD";
         var score = Fuzz.PartialRatio(_s1, _s2);
-        Assert.AreEqual(0, score);
+        Assert.Equal(0, score);
     }
 
-    [Test]
+    [Fact]
     public void TestZeroRatio()
     {
         var ratio = Fuzz.PartialTokenSortRatio("abc", "def");
@@ -199,7 +197,7 @@ public class RatioTests
         Assert.True(ratio == 0);
     }
 
-    [Test]
+    [Fact]
     public void Test03()
     {
         var ratio = Fuzz.PartialTokenSortRatio("new york mets", "atlanta braves vs new york mets");
@@ -207,24 +205,25 @@ public class RatioTests
         Assert.True(ratio == 77);
     }
 
-    [Test]
+    [Fact]
     public void TestRatioUnicodeString()
     {
         _s1 = "\u00C1";
         _s2 = "ABCD";
         var score = Fuzz.WeightedRatio(_s1, _s2);
-        Assert.AreEqual(0, score);
+        Assert.Equal(0, score);
 
         // Cyrillic.
         _s1   = "\u043f\u0441\u0438\u0445\u043e\u043b\u043e\u0433";
         _s2   = "\u043f\u0441\u0438\u0445\u043e\u0442\u0435\u0440\u0430\u043f\u0435\u0432\u0442";
         score = Fuzz.WeightedRatio(_s1, _s2);
-        Assert.AreNotEqual(0, score);
+        Assert.NotEqual(0, score);
 
         // Chinese.
         _s1   = "\u6211\u4e86\u89e3\u6570\u5b66";
         _s2   = "\u6211\u5b66\u6570\u5b66";
         score = Fuzz.WeightedRatio(_s1, _s2);
-        Assert.AreNotEqual(0, score);
+        Assert.NotEqual(0, score);
     }
 }
+

--- a/FuzzySharp.Test/FuzzyTests/RegressionTests.cs
+++ b/FuzzySharp.Test/FuzzyTests/RegressionTests.cs
@@ -1,20 +1,19 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
-using NUnit.Framework;
+using Xunit;
 using Raffinert.FuzzySharp.SimilarityRatio;
 using Raffinert.FuzzySharp.SimilarityRatio.Scorer;
 
 namespace Raffinert.FuzzySharp.Test.FuzzyTests;
 
-[TestFixture]
 public class RegressionTests
 {
 
     /// <summary>
     /// Test to ensure that all IRatioScorer implementations handle scoring empty strings & whitespace strings
     /// </summary>
-    [Test]
+    [Fact]
     public void TestScoringEmptyString()
     {
         var scorerType = typeof(IRatioScorer);

--- a/FuzzySharp.Test/FuzzyTests/ScorerTests/TokenSetScorerBaseTest.cs
+++ b/FuzzySharp.Test/FuzzyTests/ScorerTests/TokenSetScorerBaseTest.cs
@@ -1,11 +1,10 @@
-﻿using NUnit.Framework;
+using Xunit;
 using Raffinert.FuzzySharp.SimilarityRatio;
 using Raffinert.FuzzySharp.SimilarityRatio.Scorer;
 using Raffinert.FuzzySharp.SimilarityRatio.Scorer.StrategySensitive;
 
 namespace Raffinert.FuzzySharp.Test.FuzzyTests.ScorerTests;
 
-[TestFixture]
 public class TokenSetScorerBaseTest
 {
     private const string fuzzy1 = "Fuzzy Wuzzy Was A Bear";
@@ -18,45 +17,46 @@ public class TokenSetScorerBaseTest
     private IRatioScorer _scorer;
     private IRatioScorer _partialScorer;
 
-    [SetUp]
-    public void SetUp()
+    public TokenSetScorerBaseTest()
     {
         _scorer = ScorerCache.Get<TokenSetScorer>();
         _partialScorer = ScorerCache.Get<PartialTokenSetScorer>();
     }
 
-    [TestCase(fuzzy1, fuzzy1)]
-    [TestCase(fuzzy2, fuzzy2)]
-    [TestCase(nasa1, nasa1)]
-    [TestCase(nasa2, nasa2)]
+    [Theory]
+    [InlineData(fuzzy1, fuzzy1)]
+    [InlineData(fuzzy2, fuzzy2)]
+    [InlineData(nasa1, nasa1)]
+    [InlineData(nasa2, nasa2)]
     public void TokenSetScorer_SameInput_Returns100(string s1, string s2)
     {
-        Assert.That(_scorer.Score(s1, s2), Is.EqualTo(100));
-        Assert.That(_partialScorer.Score(s1, s2), Is.EqualTo(100));
+        Assert.Equal(100, _scorer.Score(s1, s2));
+        Assert.Equal(100, _partialScorer.Score(s1, s2));
     }
 
-    [Test]
+    [Fact]
     public void TokenSetScorer_OneSetContainsAllTokensOfTheOther_Returns100()
     {
-        Assert.That(_scorer.Score(fuzzy1, fuzzy2), Is.EqualTo(100));
-        Assert.That(_partialScorer.Score(fuzzy1, fuzzy2), Is.EqualTo(100));
+        Assert.Equal(100, _scorer.Score(fuzzy1, fuzzy2));
+        Assert.Equal(100, _partialScorer.Score(fuzzy1, fuzzy2));
     }
 
-    [Test]
+    [Fact]
     public void TokenSetScorer_WhenOnlySingleTokenSimilar_DoesNotReturn100()
     {
-        Assert.That(_scorer.Score(nasa1, nasa2), Is.Not.EqualTo(100));
+        Assert.NotEqual(100, _scorer.Score(nasa1, nasa2));
     }
 
-    [Test]
+    [Fact]
     public void PartialTokenSetScorer_WhenOnlySingleTokenSimilar_StillReturns100()
     {
-        Assert.That(_partialScorer.Score(nasa1, nasa2), Is.EqualTo(100));
+        Assert.Equal(100, _partialScorer.Score(nasa1, nasa2));
     }
 
-    [Test]
+    [Fact]
     public void PartialTokenSetScorer_WhenNoTokenSimilar_DoesNotReturn100()
     {
-        Assert.That(_partialScorer.Score(nasa1, nersa), Is.Not.EqualTo(100));
+        Assert.NotEqual(100, _partialScorer.Score(nasa1, nersa));
     }
 }
+

--- a/FuzzySharp.Test/LevenshteinTests.cs
+++ b/FuzzySharp.Test/LevenshteinTests.cs
@@ -54,4 +54,56 @@ public class LevenshteinTests
         Assert.That(eo.Length, Is.EqualTo(qd));
         //Assert.That(mb, Is.EquivalentTo(mb2));
     }
+
+    [Test]
+    [TestCase("abc", "adc", 1, 1, 1, 1)]
+    [TestCase("abc", "adc", 1, 1, 2, 2)]
+    [TestCase("abc", "adc", 2, 1, 1, 1)]
+    [TestCase("abc", "adc", 1, 2, 1, 1)]
+    [TestCase("abc", "adc", 2, 2, 3, 3)]
+    [TestCase("abc", "", 2, 1, 1, 3)]
+    [TestCase("", "abc", 2, 1, 1, 6)]
+    public void TestLevenshteinDistance_Weighted(string s1, string s2, int insertCost, int deleteCost, int replaceCost, int expected)
+    {
+        var distance = Levenshtein.Distance(s1, s2, insertCost, deleteCost, replaceCost);
+        Assert.That(distance, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void TestLevenshteinDistance_WeightedScoreCutoff()
+    {
+        var distance = Levenshtein.Distance("abc", "", insertCost: 2, deleteCost: 1, replaceCost: 3, scoreCutoff: 2);
+        Assert.That(distance, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void TestLevenshteinSimilarity_UsesSimilarityCutoff()
+    {
+        var similarity = Levenshtein.Similarity("kitten", "sitting", scoreCutoff: 5);
+        Assert.That(similarity, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void TestLevenshteinMaximum_MatchesExpectedFormula()
+    {
+        var maximum = Levenshtein.LevenshteinMaximum(5, 3, insertCost: 2, deleteCost: 3, replaceCost: 4);
+        Assert.That(maximum, Is.EqualTo(18));
+    }
+
+    [Test]
+    public void TestLevenshteinDistance_CutoffDoesNotExitEarly_ForRecoverablePrefix_SingleUlong()
+    {
+        var distance = Levenshtein.Distance("abc", "xabc", scoreCutoff: 1);
+        Assert.That(distance, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void TestLevenshteinDistance_CutoffDoesNotExitEarly_ForRecoverablePrefix_MultiUlong()
+    {
+        var source = new string('a', 70);
+        var target = "x" + source;
+
+        var distance = Levenshtein.Distance(source, target, scoreCutoff: 1);
+        Assert.That(distance, Is.EqualTo(1));
+    }
 }

--- a/FuzzySharp.Test/LevenshteinTests.cs
+++ b/FuzzySharp.Test/LevenshteinTests.cs
@@ -1,47 +1,47 @@
-﻿using NUnit.Framework;
+using Xunit;
 
 namespace Raffinert.FuzzySharp.Test;
 
-[TestFixture]
 public class LevenshteinTests
 {
-    [Test]
-    [TestCase(
+    [Theory]
+    [InlineData(
     "I had two heart attacks, an abortion, did crack... while I was pregnant. Other than that, I'm fine.",
     "You couldn't even be a vegetable - even artichokes have a heart.",
     76)]
-    [TestCase("", "", 0)]
-    [TestCase("a", "", 1)]
-    [TestCase("", "a", 1)]
-    [TestCase("kitten", "kitten", 0)]
-    [TestCase("kitten", "sitting", 3)]     // substitution + insertion + insertion
-    [TestCase("flaw", "lawn", 2)]          // substitution + insertion
-    [TestCase("gumbo", "gambol", 2)]       // insertion + substitution
-    [TestCase("book", "back", 2)]          // two substitutions
-    [TestCase("Sunday", "Saturday", 3)]    // insertion + substitution + insertion
+    [InlineData("", "", 0)]
+    [InlineData("a", "", 1)]
+    [InlineData("", "a", 1)]
+    [InlineData("kitten", "kitten", 0)]
+    [InlineData("kitten", "sitting", 3)]     // substitution + insertion + insertion
+    [InlineData("flaw", "lawn", 2)]          // substitution + insertion
+    [InlineData("gumbo", "gambol", 2)]       // insertion + substitution
+    [InlineData("book", "back", 2)]          // two substitutions
+    [InlineData("Sunday", "Saturday", 3)]    // substitution + insertion + insertion
     // Test a few boundary scenarios (longer strings, only one‐character difference)
-    [TestCase("a", "b", 1)]
-    [TestCase("ab", "ba", 2)]
-    [TestCase("abcdef", "azced", 3)]
-    [TestCase("distance", "difference", 5)]
+    [InlineData("a", "b", 1)]
+    [InlineData("ab", "ba", 2)]
+    [InlineData("abcdef", "azced", 3)]
+    [InlineData("distance", "difference", 5)]
     public void TestLevenshteinDistance(string s1, string s2, int expectedDistance)
     {
         int distance = Levenshtein.Distance(s1, s2);
-        Assert.AreEqual(expectedDistance, distance);
+        Assert.Equal(expectedDistance, distance);
     }
 
-    [Test]
-    public void TestLevenshteinDistance()
+    [Fact]
+    public void TestLevenshteinDistance_LongInputs()
     {
         var wordA = new string('A', 4112);
         var wordB = new string('B', 4112);
         int maxDistance = Levenshtein.Distance(wordA, wordB);
         int zeroDistance = Levenshtein.Distance(wordA, wordA);
-        Assert.AreEqual(4112, maxDistance);
-        Assert.AreEqual(0, zeroDistance);
+        Assert.Equal(4112, maxDistance);
+        Assert.Equal(0, zeroDistance);
     }
 
-    [Test, TestCaseSource(typeof(RandomWordPairs), nameof(RandomWordPairs.GetWordPairs))]
+    [Theory]
+    [MemberData(nameof(RandomWordPairs.GetWordPairs), MemberType = typeof(RandomWordPairs))]
     public void Levenshtein_ShouldBeEqual(string s1, string s2)
     {
         var fd = Levenshtein.Distance(s1, s2);
@@ -50,60 +50,61 @@ public class LevenshteinTests
         //var mb2 = global::FuzzySharp.Levenshtein.GetMatchingBlocks(s1, s2);
         var qd = Quickenshtein.Levenshtein.GetDistance(s1, s2);
 
-        Assert.That(fd, Is.EqualTo(qd));
-        Assert.That(eo.Length, Is.EqualTo(qd));
+        Assert.Equal(qd, fd);
+        Assert.Equal(qd, eo.Length);
         //Assert.That(mb, Is.EquivalentTo(mb2));
     }
 
-    [Test]
-    [TestCase("abc", "adc", 1, 1, 1, 1)]
-    [TestCase("abc", "adc", 1, 1, 2, 2)]
-    [TestCase("abc", "adc", 2, 1, 1, 1)]
-    [TestCase("abc", "adc", 1, 2, 1, 1)]
-    [TestCase("abc", "adc", 2, 2, 3, 3)]
-    [TestCase("abc", "", 2, 1, 1, 3)]
-    [TestCase("", "abc", 2, 1, 1, 6)]
+    [Theory]
+    [InlineData("abc", "adc", 1, 1, 1, 1)]
+    [InlineData("abc", "adc", 1, 1, 2, 2)]
+    [InlineData("abc", "adc", 2, 1, 1, 1)]
+    [InlineData("abc", "adc", 1, 2, 1, 1)]
+    [InlineData("abc", "adc", 2, 2, 3, 3)]
+    [InlineData("abc", "", 2, 1, 1, 3)]
+    [InlineData("", "abc", 2, 1, 1, 6)]
     public void TestLevenshteinDistance_Weighted(string s1, string s2, int insertCost, int deleteCost, int replaceCost, int expected)
     {
         var distance = Levenshtein.Distance(s1, s2, insertCost, deleteCost, replaceCost);
-        Assert.That(distance, Is.EqualTo(expected));
+        Assert.Equal(expected, distance);
     }
 
-    [Test]
+    [Fact]
     public void TestLevenshteinDistance_WeightedScoreCutoff()
     {
         var distance = Levenshtein.Distance("abc", "", insertCost: 2, deleteCost: 1, replaceCost: 3, scoreCutoff: 2);
-        Assert.That(distance, Is.EqualTo(3));
+        Assert.Equal(3, distance);
     }
 
-    [Test]
+    [Fact]
     public void TestLevenshteinSimilarity_UsesSimilarityCutoff()
     {
         var similarity = Levenshtein.Similarity("kitten", "sitting", scoreCutoff: 5);
-        Assert.That(similarity, Is.EqualTo(0));
+        Assert.Equal(0, similarity);
     }
 
-    [Test]
+    [Fact]
     public void TestLevenshteinMaximum_MatchesExpectedFormula()
     {
         var maximum = Levenshtein.LevenshteinMaximum(5, 3, insertCost: 2, deleteCost: 3, replaceCost: 4);
-        Assert.That(maximum, Is.EqualTo(18));
+        Assert.Equal(18, maximum);
     }
 
-    [Test]
+    [Fact]
     public void TestLevenshteinDistance_CutoffDoesNotExitEarly_ForRecoverablePrefix_SingleUlong()
     {
         var distance = Levenshtein.Distance("abc", "xabc", scoreCutoff: 1);
-        Assert.That(distance, Is.EqualTo(1));
+        Assert.Equal(1, distance);
     }
 
-    [Test]
+    [Fact]
     public void TestLevenshteinDistance_CutoffDoesNotExitEarly_ForRecoverablePrefix_MultiUlong()
     {
         var source = new string('a', 70);
         var target = "x" + source;
 
         var distance = Levenshtein.Distance(source, target, scoreCutoff: 1);
-        Assert.That(distance, Is.EqualTo(1));
+        Assert.Equal(1, distance);
     }
 }
+

--- a/FuzzySharp.Test/LongestCommonSubsequenceTests.cs
+++ b/FuzzySharp.Test/LongestCommonSubsequenceTests.cs
@@ -1,16 +1,16 @@
-﻿using System;
-using NUnit.Framework;
+using System;
+using Xunit;
 using Raffinert.FuzzySharp.Edits;
 
 namespace Raffinert.FuzzySharp.Test;
 
 public class LongestCommonSubsequenceTests
 {
-    [Test]
+    [Fact]
     public void LongestCommonSubsequence_MatchingBlocks_ReturnsExpectedEditOps()
     {
         var lcsBlocks = LongestCommonSubsequence.MatchingBlocks("xasdfxxxxxxxxxxxxxxxxxxxasdfxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxasdfx".AsSpan(), "aabbcc".AsSpan());
-        Assert.That(lcsBlocks, Is.EquivalentTo(new[]
+        Assert.Equivalent(lcsBlocks, new[]
         {
             new MatchingBlock
             {
@@ -28,6 +28,6 @@ public class LongestCommonSubsequenceTests
                 SourcePos = 73,
                 DestPos = 6,
                 Length = 0
-            }}));
+            }});
     }
 }

--- a/FuzzySharp.Test/RandomWords.cs
+++ b/FuzzySharp.Test/RandomWords.cs
@@ -1,4 +1,3 @@
-﻿using NUnit.Framework;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -8,13 +7,13 @@ namespace Raffinert.FuzzySharp.Test;
 
 public static class RandomWordPairs
 {
-    public static IEnumerable<TestCaseData> GetWordPairs()
+    public static IEnumerable<object[]> GetWordPairs()
     {
         var words = RandomWords.Create(50, 1024);
 
         var result = from word1 in words
                      from word2 in words
-                     select new TestCaseData(word1, word2);
+                     select new object[] { word1, word2 };
 
         return result;
     }
@@ -76,3 +75,4 @@ public static class RandomWords
     public delegate void SpanAction<T, in TArg>(Span<T> span, TArg arg);
 #endif
 }
+

--- a/FuzzySharp/FuzzySharp.csproj
+++ b/FuzzySharp/FuzzySharp.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48'">
-    <PackageReference Include="IndexRange" Version="1.0.3" />
+    <PackageReference Include="IndexRange" Version="1.1.1" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
@@ -40,7 +40,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Meziantou.Polyfill" Version="1.0.49">
+        <PackageReference Include="Meziantou.Polyfill" Version="1.0.131">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/FuzzySharp/FuzzySharp.csproj
+++ b/FuzzySharp/FuzzySharp.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <FileVersion>5.0.1.0</FileVersion>
-    <Version>5.0.1</Version>
-    <PackageVersion>5.0.1</PackageVersion>
-    <AssemblyVersion>5.0.1.0</AssemblyVersion>
-    <FileVersion>5.0.1.0</FileVersion>
-    <Version>5.0.1</Version>
-    <PackageVersion>5.0.1</PackageVersion>
+    <FileVersion>5.0.2.0</FileVersion>
+    <Version>5.0.2</Version>
+    <PackageVersion>5.0.2</PackageVersion>
+    <AssemblyVersion>5.0.2.0</AssemblyVersion>
+    <FileVersion>5.0.2.0</FileVersion>
+    <Version>5.0.2</Version>
+    <PackageVersion>5.0.2</PackageVersion>
     <Authors>Jacob Bayer;Yevhen Cherkes</Authors>
     <Company />
     <Description>

--- a/FuzzySharp/Levenshtein.Static.cs
+++ b/FuzzySharp/Levenshtein.Static.cs
@@ -47,11 +47,16 @@ public sealed partial class Levenshtein
         int insertCost = 1, int deleteCost = 1, int replaceCost = 1,
         int? scoreCutoff = null) where T : IEquatable<T>
     {
-        SequenceUtils.TrimCommonAffixAndSwapIfNeeded(ref source, ref target);
+        SequenceUtils.TrimCommonAffix(ref source, ref target);
 
-        if (insertCost != 1 && deleteCost != 1 && replaceCost is not (1 or 2))
+        if (insertCost == deleteCost)
         {
-            GenericDistance(source, target, insertCost, deleteCost, replaceCost, scoreCutoff);
+            SequenceUtils.SwapIfSourceIsLonger(ref source, ref target);
+        }
+
+        if (insertCost != 1 || deleteCost != 1 || (replaceCost != 1 && replaceCost != 2))
+        {
+            return GenericDistance(source, target, insertCost, deleteCost, replaceCost, scoreCutoff);
         }
 
         using var patternMatchVector = PatternMatchVector.Create(source);
@@ -283,8 +288,8 @@ public sealed partial class Levenshtein
         // Cost of replacing common prefix and handling extra characters
         var common = len1 < len2 ? len1 : len2;
         var extraCost = len1 >= len2
-            ? len1 - len2 * deleteCost
-            : len2 - len1 * insertCost;
+            ? (len1 - len2) * deleteCost
+            : (len2 - len1) * insertCost;
 
         var replaceAndDiff = common * replaceCost + extraCost;
 
@@ -334,68 +339,49 @@ public sealed partial class Levenshtein
         var matrixVP = new List<ulong[]>();
         var matrixVN = new List<ulong[]>();
 
-        // Temporary arrays for per‐character computation
-        var D0 = new ulong[blocks];
-        var HP = new ulong[blocks];
-        var HN = new ulong[blocks];
-        var sum = new ulong[blocks];
-        var HPs = new ulong[blocks];
-        var HNs = new ulong[blocks];
-
         // Process each character of the text
         for (var i = 0; i < text.Length; i++)
         {
             // 1) Load the pattern‐mask for c, or zeros if not present
             var X = blockTable.GetOrZero(text[i]);
 
-            // 2) Compute D0 = (((X & VP) + VP) ^ VP) | X | VN
-            //    -> Must do a big‐integer add and carry across blocks
+            // 2) Compute/update in one loop (D0/HP/HN + shift + VP/VN)
             ulong carry = 0;
-            for (var b = 0; b < blocks; b++)
-            {
-                var Pv = VP[b];
-                var XandVP = X[b] & Pv;
-                // big‐integer add: XandVP + Pv + carry
-                var t = unchecked(XandVP + Pv);
-                var c1 = t < XandVP ? 1UL : 0UL;          // carry from first add
-                var t2 = unchecked(t + carry);
-                var c2 = t2 < carry ? 1UL : 0UL;           // carry from second add
-                carry = c1 | c2;
-
-                sum[b] = t2;
-                D0[b] = (sum[b] ^ Pv) | X[b] | VN[b];
-            }
-
-            // 3) HP = VN | ~(D0 | VP),   HN = D0 & VP
-            for (var b = 0; b < blocks; b++)
-            {
-                HP[b] = VN[b] | ~(D0[b] | VP[b]);
-                HN[b] = D0[b] & VP[b];
-            }
-
-            // 4) Update distance by inspecting the highest bit
-            if ((HP[lastBlk] & topBitMask) != 0) currDist++;
-            if ((HN[lastBlk] & topBitMask) != 0) currDist--;
-
-            // 5) Shift HP and HN left by one over the entire multi‐block vector
-            //    and set the low bit of HP[0] to 1
             ulong carryHP = 1, carryHN = 0;
             for (var b = 0; b < blocks; b++)
             {
-                ulong hpb = HP[b], hnb = HN[b];
-                var newCarryHP = hpb >> 63;
-                var newCarryHN = hnb >> 63;
-                HPs[b] = (hpb << 1) | carryHP;
-                HNs[b] = (hnb << 1) | carryHN;
-                carryHP = newCarryHP;
-                carryHN = newCarryHN;
-            }
+                var pv = VP[b];
+                var vn = VN[b];
+                var x = X[b] | vn;
+                var xAndVp = X[b] & pv;
 
-            // 6) Recompute VP, VN
-            for (var b = 0; b < blocks; b++)
-            {
-                VP[b] = HNs[b] | ~(D0[b] | HPs[b]);
-                VN[b] = HPs[b] & D0[b];
+                // big‐integer add: (X & VP) + VP + carry
+                var t = unchecked(xAndVp + pv);
+                var c1 = t < xAndVp ? 1UL : 0UL;
+                var sum = unchecked(t + carry);
+                var c2 = sum < t ? 1UL : 0UL;
+                carry = c1 | c2;
+
+                var d0 = (sum ^ pv) | x;
+                var hp = vn | ~(d0 | pv);
+                var hn = d0 & pv;
+
+                if (b == lastBlk)
+                {
+                    if ((hp & topBitMask) != 0) currDist++;
+                    if ((hn & topBitMask) != 0) currDist--;
+                }
+
+                var nextCarryHP = hp >> 63;
+                var nextCarryHN = hn >> 63;
+                hp = (hp << 1) | carryHP;
+                hn = (hn << 1) | carryHN;
+
+                VP[b] = hn | ~(d0 | hp);
+                VN[b] = hp & d0;
+
+                carryHP = nextCarryHP;
+                carryHN = nextCarryHN;
             }
 
             // 7) Keep a snapshot of VP/VN for this character
@@ -519,7 +505,8 @@ public sealed partial class Levenshtein
         int insertCost = 1, int deleteCost = 1, int replaceCost = 1,
         double? scoreCutoff = null)
     {
-        var nd = NormalizedDistance(source, target, insertCost, deleteCost, replaceCost, scoreCutoff);
+        double? distanceCutoff = 1.0 - scoreCutoff;
+        var nd = NormalizedDistance(source, target, insertCost, deleteCost, replaceCost, distanceCutoff);
         var ns = 1.0 - nd;
 
         return ns < scoreCutoff ? 0.0 : ns;
@@ -558,7 +545,10 @@ public sealed partial class Levenshtein
     {
         int len1 = source.Length, len2 = target.Length;
         var maximum = LevenshteinMaximum(len1, len2, insertCost, deleteCost, replaceCost);
-        var dist = Distance(source, target, insertCost, deleteCost, replaceCost, scoreCutoff);
+        int? distanceCutoff = scoreCutoff.HasValue
+            ? Math.Max(0, maximum - scoreCutoff.Value)
+            : null;
+        var dist = Distance(source, target, insertCost, deleteCost, replaceCost, distanceCutoff);
         var sim = maximum - dist;
         return sim < scoreCutoff ? 0 : sim;
     }
@@ -667,7 +657,7 @@ public sealed partial class Levenshtein
 
         // Number of 64‐bit blocks needed to cover pattern length m
         var blocks = (m + 63) >> 6;
-        var totalScratch = 6 * blocks;
+        var totalScratch = 2 * blocks;
         var scratchArray = ArrayPool<ulong>.Shared.Rent(totalScratch);
         try
         {
@@ -683,13 +673,9 @@ public sealed partial class Levenshtein
 
     // ─────────────────────────────────────────────────────────────────────────────
     // Shared implementation that uses the precomputed dictionary of masks.
-    // 'scratch' must have Length == 6 * blocks. It is partitioned into six lanes:
+    // 'scratch' must have Length == 2 * blocks. It is partitioned into two lanes:
     //   scratch[0..blocks)       → VP
     //   scratch[blocks..2*blocks)→ VN
-    //   scratch[2*blocks..3*blocks)→ X
-    //   scratch[3*blocks..4*blocks)→ D0
-    //   scratch[4*blocks..5*blocks)→ HP
-    //   scratch[5*blocks..6*blocks)→ HN
     // ─────────────────────────────────────────────────────────────────────────────
     private static int DistanceMultipleULongsImpl<T>(IPatternMatchVector<T> sourceVector, 
         ReadOnlySpan<T> target,
@@ -698,13 +684,9 @@ public sealed partial class Levenshtein
         int blocks,
         Span<ulong> scratch) where T : IEquatable<T>
     {
-        // Partition scratch into six spans of length = blocks
+        // Partition scratch into two spans of length = blocks
         var VP = scratch.Slice(0 * blocks, blocks);
         var VN = scratch.Slice(1 * blocks, blocks);
-        var X = scratch.Slice(2 * blocks, blocks);
-        var D0 = scratch.Slice(3 * blocks, blocks);
-        var HP = scratch.Slice(4 * blocks, blocks);
-        var HN = scratch.Slice(5 * blocks, blocks);
 
         // Initialize VP (low m bits = 1) and VN = 0
         for (var b = 0; b < blocks; b++)
@@ -730,15 +712,16 @@ public sealed partial class Levenshtein
             // Look up the precomputed bitmask array, or use zeroMask if not found
             var PMitem = sourceVector.GetOrZero(target[i]);
 
-            // “D0‐loop” with carry across blocks
+            // Update in one loop (D0/HP/HN + shift + VP/VN)
             var carry = 0UL;
+            var carryHP = 1UL;
+            var carryHN = 0UL;
             for (var b = 0; b < blocks; b++)
             {
                 var pm = PMitem[b];
                 var vp = VP[b];
                 var vn = VN[b];
                 var x = pm | vn;
-                X[b] = x;
                 var tmp = x & vp;
 
                 // tmp + vp
@@ -749,31 +732,15 @@ public sealed partial class Levenshtein
                 var c2o = (sum < sum1) ? 1UL : 0UL;
                 carry = c1 | c2o;
 
-                // D0 = (sum ^ vp) | x
                 var d0 = (sum ^ vp) | x;
-                D0[b] = d0;
+                var hp = vn | ~(d0 | vp);
+                var hn = d0 & vp;
 
-                // HP = vn | ~(d0 | vp)
-                // HN = d0 & vp
-                HP[b] = vn | ~(d0 | vp);
-                HN[b] = d0 & vp;
-            }
-
-            // Update distance by checking top bit of last block
-            if ((HP[last] & highestBitMask) != 0UL) dist++;
-            if ((HN[last] & highestBitMask) != 0UL) dist--;
-            if (scoreCutoff.HasValue && dist > scoreCutoff.Value)
-            {
-                return scoreCutoff.Value + 1;
-            }
-
-            // Shift HP/HN left by 1 (with cross‐block carry), then compute new VP/VN
-            var carryHP = 1UL;
-            var carryHN = 0UL;
-            for (var b = 0; b < blocks; b++)
-            {
-                var hp = HP[b];
-                var hn = HN[b];
+                if (b == last)
+                {
+                    if ((hp & highestBitMask) != 0UL) dist++;
+                    if ((hn & highestBitMask) != 0UL) dist--;
+                }
 
                 var hpHigh = hp >> 63;
                 var hnHigh = hn >> 63;
@@ -781,12 +748,20 @@ public sealed partial class Levenshtein
                 hp = (hp << 1) | carryHP;
                 hn = (hn << 1) | carryHN;
 
-                var d0 = D0[b];
                 VP[b] = hn | ~(d0 | hp);
                 VN[b] = hp & d0;
 
                 carryHP = hpHigh;
                 carryHN = hnHigh;
+            }
+
+            if (scoreCutoff.HasValue)
+            {
+                var remaining = target.Length - (i + 1);
+                if (dist > scoreCutoff.Value + remaining)
+                {
+                    return scoreCutoff.Value + 1;
+                }
             }
         }
 
@@ -820,7 +795,8 @@ public sealed partial class Levenshtein
             if ((HP & highestBit) != 0) dist++;
             if ((HN & highestBit) != 0) dist--;
 
-            if (dist > scoreCutoff)
+            var remaining = target.Length - (i + 1);
+            if (dist > scoreCutoff + remaining)
                 return scoreCutoff + 1;
 
             // shift in

--- a/FuzzySharp/LongestCommonSubsequence.Static.cs
+++ b/FuzzySharp/LongestCommonSubsequence.Static.cs
@@ -232,10 +232,10 @@ public sealed partial class LongestCommonSubsequence
             return 0.0;
 
         int maximum = Math.Max(s1.Length, s2.Length);
-        double normSim = Distance(s1, s2) / (double)maximum;
+        double normDist = Distance(s1, s2) / (double)maximum;
 
-        var result = !scoreCutoff.HasValue || normSim <= scoreCutoff.Value
-            ? normSim
+        var result = !scoreCutoff.HasValue || normDist <= scoreCutoff.Value
+            ? normDist
             : 1.0;
 
         return result;
@@ -394,52 +394,48 @@ public sealed partial class LongestCommonSubsequence
             return 0;
 
         int len1 = s1Vector.Length;
-        int segCount = (len1 + 63) / 64;
+        int blockCount = (len1 + 63) / 64;
 
-        var scratch = ArrayPool<ulong>.Shared.Rent(segCount * 4);
+        var scratch = ArrayPool<ulong>.Shared.Rent(blockCount);
         try
         {
-            var S = scratch.AsSpan(0, segCount);
-            var u = scratch.AsSpan(segCount, segCount);
-            var add = scratch.AsSpan(segCount * 2, segCount);
-            var sub = scratch.AsSpan(segCount * 3, segCount);
+            var S = scratch.AsSpan(0, blockCount);
 
             // --- 2) prepare the \"all-ones up to len1\" mask and state S ---
             S.Fill(ulong.MaxValue);
             int rem = len1 & 63;
             if (rem != 0)
-                S[segCount - 1] = (1UL << rem) - 1;
+                S[blockCount - 1] = (1UL << rem) - 1;
 
             // --- 3) main bit-parallel loop: S = (S + u) | (S - u)  ---
             for (int chIdx = 0; chIdx < s2.Length; chIdx++)
             {
-                var M = s1Vector.GetOrZero(s2[chIdx]);
+                var U = s1Vector.GetOrZero(s2[chIdx]);
 
-                // u = S & M
-                for (int i = 0; i < segCount; i++)
-                    u[i] = S[i] & M[i];
-
-                // add = S + u  (multi-precision)
+                // big-integer add/subtract using u = S & U
                 ulong carry = 0;
-                for (int i = 0; i < segCount; i++)
-                {
-                    ulong sum = S[i] + u[i] + carry;
-                    carry = sum < S[i] || (carry == 1 && sum == S[i]) ? 1UL : 0UL;
-                    add[i] = sum;
-                }
-
-                // sub = S - u  (multi-precision)
                 ulong borrow = 0;
-                for (int i = 0; i < segCount; i++)
+                for (int b = 0; b < blockCount; b++)
                 {
-                    ulong diff = S[i] - u[i] - borrow;
-                    borrow = S[i] < u[i] + borrow ? 1UL : 0UL;
-                    sub[i] = diff;
-                }
+                    ulong s = S[b];
+                    ulong u = s & U[b];
 
-                // new S = add | sub
-                for (int i = 0; i < segCount; i++)
-                    S[i] = add[i] | sub[i];
+                    // Sum = S + u
+                    ulong t = unchecked(s + u);
+                    ulong c1 = t < s ? 1UL : 0UL;
+                    ulong sum = unchecked(t + carry);
+                    ulong c2 = sum < t ? 1UL : 0UL;
+                    carry = c1 | c2;
+
+                    // Diff = S - u
+                    ulong t1 = unchecked(s - u);
+                    ulong b1 = s < u ? 1UL : 0UL;
+                    ulong diff = unchecked(t1 - borrow);
+                    ulong b2 = t1 < borrow ? 1UL : 0UL;
+                    borrow = b1 | b2;
+                    // update S = Sum | Diff
+                    S[b] = sum | diff;
+                }
             }
 
             // --- 4) count zero bits in the lower len1 positions of S ---
@@ -501,16 +497,14 @@ public sealed partial class LongestCommonSubsequence
         }
 
         // build blockTable: element → bit-mask array
-        using var blockTable = PatternMatchVector.Create(s1);
+        using var s1Vector = PatternMatchVector.Create(s1);
 
         var matrix = new List<ulong[]>(s2.Length);
-        var sum = new ulong[blocks];
-        var diff = new ulong[blocks];
 
         foreach (var y in s2)
         {
             // load mask for y
-            var U = blockTable.GetOrZero(y);
+            var U = s1Vector.GetOrZero(y);
 
             // big-integer add/subtract using u = S & U
             ulong carry = 0;
@@ -524,23 +518,19 @@ public sealed partial class LongestCommonSubsequence
                 // Sum = S + u
                 ulong t = unchecked(s + u);
                 ulong c1 = t < s ? 1UL : 0UL;
-                ulong t2 = unchecked(t + carry);
-                ulong c2 = t2 < t ? 1UL : 0UL;
-                sum[b] = t2;
+                ulong sum = unchecked(t + carry);
+                ulong c2 = sum < t ? 1UL : 0UL;
                 carry = c1 | c2;
 
                 // Diff = S - u
                 ulong t1 = unchecked(s - u);
                 ulong b1 = s < u ? 1UL : 0UL;
-                ulong t3 = unchecked(t1 - borrow);
+                ulong diff = unchecked(t1 - borrow);
                 ulong b2 = t1 < borrow ? 1UL : 0UL;
-                diff[b] = t3;
                 borrow = b1 | b2;
+                // update S = Sum | Diff
+                S[b] = sum | diff;
             }
-
-            // update S = Sum | Diff
-            for (int b = 0; b < blocks; b++)
-                S[b] = sum[b] | diff[b];
 
             // snapshot row
             matrix.Add((ulong[])S.Clone());


### PR DESCRIPTION
## What Changed

### 1) LongestCommonSubsequence correctness and loop consolidation

- Fixed multi-block update logic to use `u = S & U` before arithmetic in both:
  - `BlockSimilarityMultipleULongs`
  - `MatrixMultipleULongs`
- Consolidated add/subtract/update into a single block loop per character.
- Reduced temporary scratch usage in `BlockSimilarityMultipleULongs` from 4 block-sized buffers to 1 (`S`).
- Minor naming cleanup (`segCount` -> `blockCount`, `blockTable` -> `s1Vector`) for clarity.

### 2) Levenshtein weighted-path/cutoff correctness

- In `Distance<T>`:
  - Separated trim and swap behavior:
    - always trim common affix
    - only swap inputs when `insertCost == deleteCost`
  - Fixed weighted dispatch and return path to correctly execute `GenericDistance` for non-fast-path weights.
- Corrected `LevenshteinMaximum` length-difference cost math with proper parentheses.
- Updated `Similarity(...)` to convert similarity cutoff to distance cutoff using:
  - `distanceCutoff = max(0, maximum - similarityCutoff)`
- Updated `NormalizedSimilarity(...)` to pass converted cutoff into normalized distance path:
  - `distanceCutoff = 1.0 - similarityCutoff`

### 3) Levenshtein multi-block loop refactor

- Refactored `MatrixMultipleULongs` to a one-loop-per-block update style (compute/update in one pass).
- Refactored `DistanceMultipleULongsImpl` similarly:
  - merged D0/HP/HN + shift + VP/VN update into one block loop
  - moved score-cutoff check to run once per processed target symbol
- Reduced pooled scratch size for distance multi-block path:
  - from `6 * blocks` (then `5 * blocks`) to `2 * blocks` (`VP` and `VN` only)

### 4) Strict-safe cutoff short-circuit for Levenshtein distance

- Replaced unsafe early return checks (`dist > scoreCutoff`) with a strict lower-bound check in both:
  - `DistanceSingleULong`
  - `DistanceMultipleULongsImpl`
- New check uses remaining target length to prove impossibility of recovery:
  - `remaining = target.Length - (i + 1)`
  - early return only when `dist > scoreCutoff + remaining`
- This preserves cutoff performance while guaranteeing correctness (no false early exits on recoverable prefixes).

## Tests Added

Added coverage in `FuzzySharp.Test/LevenshteinTests.cs` for:

- weighted distance combinations
- weighted distance cutoff behavior
- similarity cutoff behavior
- `LevenshteinMaximum` formula behavior
- recoverable-prefix cutoff safety for single-ulong path
- recoverable-prefix cutoff safety for multi-ulong path (>64 chars)

## All tests migrated to xunit

## Notes

- Functional correctness aligns closer with RapidFuzz distance/similarity cutoff semantics.
- The cutoff short-circuit now follows a strict-safe bound-based rule rather than a naive row-value threshold.
