### PR TITLE
Refactor and optimize selection logic in ResultExtractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.0.3
+
+- Improved parallel `ExtractOne` selection by reducing each worker's local best candidate before the final result is selected, preserving deterministic score and index tie-breaking.
+
 ## v5.0.2
 
 *Levenshtein/LCS correctness and cutoff semantics*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## v5.0.3
 
-- Improved parallel `ExtractOne` selection by reducing each worker's local best candidate before the final result is selected, preserving deterministic score and index tie-breaking.
+*Extractor selection performance and allocation improvements*
+
+- Optimized `ExtractOne` and `ExtractTop` across the standard, cached, parallel, and parallel-cached extractors by selecting candidates directly instead of materializing every qualifying `ExtractedResult` and then using LINQ `Max` or `MaxN`.
+- `ExtractOne` now tracks the best candidate during scoring; `ExtractTop` retains only the requested number of candidates in a bounded heap.
+- Parallel extractors score candidates independently and reduce local results while preserving score ordering and first-occurrence tie-breaking.
+- Added extractor selection regression tests and benchmarks for sequential, cached, parallel, and parallel-cached paths.
 
 ## v5.0.2
 

--- a/FuzzySharp.Benchmarks/ExtractSelectionBenchmarks.cs
+++ b/FuzzySharp.Benchmarks/ExtractSelectionBenchmarks.cs
@@ -1,0 +1,529 @@
+using BenchmarkDotNet.Attributes;
+using Raffinert.FuzzySharp.Extractor;
+using Raffinert.FuzzySharp.Extensions;
+using Raffinert.FuzzySharp.SimilarityRatio;
+using Raffinert.FuzzySharp.SimilarityRatio.Scorer;
+using Raffinert.FuzzySharp.SimilarityRatio.Scorer.Composite;
+using System.Threading.Tasks;
+
+namespace Raffinert.FuzzySharp.Benchmarks;
+
+public enum ExtractSelectionScorerKind
+{
+    Cheap,
+    WeightedRatio
+}
+
+[MemoryDiagnoser]
+[RankColumn]
+public class ExtractSelectionOneBenchmarks
+{
+    private readonly ParallelOptions _parallelOptions = new() { MaxDegreeOfParallelism = 4 };
+    private string[] _choices = null!;
+    private IRatioScorer _scorer = null!;
+    private ICachedRatioScorer _cachedScorer = null!;
+
+    [Params(1_000, 10_000, 100_000)]
+    public int ChoiceCount { get; set; }
+
+    [Params(0, 95)]
+    public int Cutoff { get; set; }
+
+    [Params(ExtractSelectionScorerKind.Cheap, ExtractSelectionScorerKind.WeightedRatio)]
+    public ExtractSelectionScorerKind ScorerKind { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _choices = CreateChoices(ChoiceCount);
+        _scorer = ScorerKind == ExtractSelectionScorerKind.Cheap
+            ? new CheapScorer()
+            : ScorerCache.Get<WeightedRatioScorer>();
+        _cachedScorer = ScorerKind == ExtractSelectionScorerKind.Cheap
+            ? new CheapCachedScorer()
+            : new CachedWeightedRatioScorer(Query);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _cachedScorer.Dispose();
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Optimized_ExtractOne()
+    {
+        return ResultExtractor.ExtractOne(Query, _choices, Identity, _scorer, Cutoff);
+    }
+
+    [Benchmark(Baseline = true)]
+    public ExtractedResult<string> Legacy_ExtractOne()
+    {
+        return LegacyExtractWithoutOrder(Query, _choices, Identity, _scorer, Cutoff).Max()!;
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Optimized_Cached_ExtractOne()
+    {
+        return ResultExtractor.Cached.ExtractOne(_choices, Identity, _cachedScorer, Cutoff);
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Legacy_Cached_ExtractOne()
+    {
+        return LegacyCachedExtractWithoutOrder(_choices, Identity, _cachedScorer, Cutoff).Max()!;
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Optimized_Parallel_ExtractOne()
+    {
+        return ResultExtractor.Parallel.ExtractOne(Query, _choices, Identity, _scorer, Cutoff, _parallelOptions);
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Legacy_Parallel_ExtractOne()
+    {
+        return LegacyParallelExtractWithoutOrder(Query, _choices, Identity, _scorer, Cutoff, _parallelOptions).Max()!;
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Optimized_ParallelCached_ExtractOne()
+    {
+        return ResultExtractor.Parallel.Cached.ExtractOne(_choices, Identity, _cachedScorer, Cutoff, _parallelOptions);
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Legacy_ParallelCached_ExtractOne()
+    {
+        return LegacyParallelCachedExtractWithoutOrder(_choices, Identity, _cachedScorer, Cutoff, _parallelOptions).Max()!;
+    }
+
+    internal const string Query = "choice 99999 chicago cubs vs new york mets";
+
+    internal static readonly Func<string, string> Identity = static value => value;
+
+    internal static string[] CreateChoices(int count)
+    {
+        var choices = new string[count];
+        for (var i = 0; i < choices.Length; i++)
+        {
+            choices[i] = $"choice {i} chicago cubs vs new york mets";
+        }
+
+        return choices;
+    }
+
+    internal static IEnumerable<ExtractedResult<string>> LegacyExtractWithoutOrder(
+        string query,
+        IEnumerable<string> choices,
+        Func<string, string> processor,
+        IRatioScorer scorer,
+        int cutoff)
+    {
+        var index = 0;
+        var processedQuery = processor(query);
+
+        foreach (var choice in choices)
+        {
+            var score = scorer.Score(processedQuery, processor(choice));
+            if (score >= cutoff)
+            {
+                yield return new ExtractedResult<string>(choice, score, index);
+            }
+
+            index++;
+        }
+    }
+
+    internal static IEnumerable<ExtractedResult<string>> LegacyCachedExtractWithoutOrder(
+        IEnumerable<string> choices,
+        Func<string, string> processor,
+        ICachedRatioScorer scorer,
+        int cutoff)
+    {
+        var index = 0;
+
+        foreach (var choice in choices)
+        {
+            var score = scorer.Score(processor(choice));
+            if (score >= cutoff)
+            {
+                yield return new ExtractedResult<string>(choice, score, index);
+            }
+
+            index++;
+        }
+    }
+
+    internal static IEnumerable<ExtractedResult<string>> LegacyParallelExtractWithoutOrder(
+        string query,
+        IEnumerable<string> choices,
+        Func<string, string> processor,
+        IRatioScorer scorer,
+        int cutoff,
+        ParallelOptions parallelOptions)
+    {
+        var materializedChoices = choices.ToList();
+        var result = new ExtractedResult<string>[materializedChoices.Count];
+        var processedQuery = processor(query);
+
+        Parallel.ForEach(materializedChoices, parallelOptions, (choice, _, index) =>
+        {
+            var score = scorer.Score(processedQuery, processor(choice));
+            if (score >= cutoff)
+            {
+                result[index] = new ExtractedResult<string>(choice, score, (int)index);
+            }
+        });
+
+        return result.Where(static result => result != null);
+    }
+
+    internal static IEnumerable<ExtractedResult<string>> LegacyParallelCachedExtractWithoutOrder(
+        IEnumerable<string> choices,
+        Func<string, string> processor,
+        ICachedRatioScorer scorer,
+        int cutoff,
+        ParallelOptions parallelOptions)
+    {
+        var materializedChoices = choices.ToList();
+        var result = new ExtractedResult<string>[materializedChoices.Count];
+
+        Parallel.ForEach(materializedChoices, parallelOptions, (choice, _, index) =>
+        {
+            var score = scorer.Score(processor(choice));
+            if (score >= cutoff)
+            {
+                result[index] = new ExtractedResult<string>(choice, score, (int)index);
+            }
+        });
+
+        return result.Where(static result => result != null);
+    }
+
+    private sealed class CheapScorer : IRatioScorer
+    {
+        public int Score(string input1, string input2)
+        {
+            return ScoreFromChoice(input2);
+        }
+
+        public int Score(string input1, string input2, Func<string, string> preprocessor)
+        {
+            return Score(preprocessor(input1), preprocessor(input2));
+        }
+    }
+
+    private sealed class CheapCachedScorer : ICachedRatioScorer
+    {
+        public int Score(string input2)
+        {
+            return ScoreFromChoice(input2);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private static int ScoreFromChoice(string value)
+    {
+        var start = "choice ".Length;
+        var end = value.IndexOf(' ', start);
+        return int.Parse(value.AsSpan(start, end - start)) % 100;
+    }
+}
+
+[MemoryDiagnoser]
+[RankColumn]
+public class ExtractSelectionTopBenchmarks
+{
+    private readonly ParallelOptions _parallelOptions = new() { MaxDegreeOfParallelism = 4 };
+    private string[] _choices = null!;
+    private IRatioScorer _scorer = null!;
+    private ICachedRatioScorer _cachedScorer = null!;
+
+    [Params(1_000, 10_000, 100_000)]
+    public int ChoiceCount { get; set; }
+
+    [Params(1, 5, 10, 100)]
+    public int Limit { get; set; }
+
+    [Params(0, 95)]
+    public int Cutoff { get; set; }
+
+    [Params(ExtractSelectionScorerKind.Cheap, ExtractSelectionScorerKind.WeightedRatio)]
+    public ExtractSelectionScorerKind ScorerKind { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _choices = ExtractSelectionOneBenchmarks.CreateChoices(ChoiceCount);
+        _scorer = ScorerKind == ExtractSelectionScorerKind.Cheap
+            ? new CheapScorer()
+            : ScorerCache.Get<WeightedRatioScorer>();
+        _cachedScorer = ScorerKind == ExtractSelectionScorerKind.Cheap
+            ? new CheapCachedScorer()
+            : new CachedWeightedRatioScorer(ExtractSelectionOneBenchmarks.Query);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _cachedScorer.Dispose();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Optimized_ExtractTop()
+    {
+        return ResultExtractor.ExtractTop(ExtractSelectionOneBenchmarks.Query, _choices, ExtractSelectionOneBenchmarks.Identity, _scorer, Limit, Cutoff).ToList();
+    }
+
+    [Benchmark(Baseline = true)]
+    public List<ExtractedResult<string>> Legacy_ExtractTop()
+    {
+        return ExtractSelectionOneBenchmarks.LegacyExtractWithoutOrder(ExtractSelectionOneBenchmarks.Query, _choices, ExtractSelectionOneBenchmarks.Identity, _scorer, Cutoff)
+            .MaxN(Limit)
+            .Reverse()
+            .ToList();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Optimized_Cached_ExtractTop()
+    {
+        return ResultExtractor.Cached.ExtractTop(_choices, ExtractSelectionOneBenchmarks.Identity, _cachedScorer, Limit, Cutoff).ToList();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Legacy_Cached_ExtractTop()
+    {
+        return ExtractSelectionOneBenchmarks.LegacyCachedExtractWithoutOrder(_choices, ExtractSelectionOneBenchmarks.Identity, _cachedScorer, Cutoff)
+            .MaxN(Limit)
+            .Reverse()
+            .ToList();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Optimized_Parallel_ExtractTop()
+    {
+        return ResultExtractor.Parallel.ExtractTop(ExtractSelectionOneBenchmarks.Query, _choices, ExtractSelectionOneBenchmarks.Identity, _scorer, Limit, Cutoff, _parallelOptions).ToList();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Legacy_Parallel_ExtractTop()
+    {
+        return ExtractSelectionOneBenchmarks.LegacyParallelExtractWithoutOrder(ExtractSelectionOneBenchmarks.Query, _choices, ExtractSelectionOneBenchmarks.Identity, _scorer, Cutoff, _parallelOptions)
+            .MaxN(Limit)
+            .Reverse()
+            .ToList();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Optimized_ParallelCached_ExtractTop()
+    {
+        return ResultExtractor.Parallel.Cached.ExtractTop(_choices, ExtractSelectionOneBenchmarks.Identity, _cachedScorer, Limit, Cutoff, _parallelOptions).ToList();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Legacy_ParallelCached_ExtractTop()
+    {
+        return ExtractSelectionOneBenchmarks.LegacyParallelCachedExtractWithoutOrder(_choices, ExtractSelectionOneBenchmarks.Identity, _cachedScorer, Cutoff, _parallelOptions)
+            .MaxN(Limit)
+            .Reverse()
+            .ToList();
+    }
+
+    private sealed class CheapScorer : IRatioScorer
+    {
+        public int Score(string input1, string input2)
+        {
+            return ScoreFromChoice(input2);
+        }
+
+        public int Score(string input1, string input2, Func<string, string> preprocessor)
+        {
+            return Score(preprocessor(input1), preprocessor(input2));
+        }
+    }
+
+    private sealed class CheapCachedScorer : ICachedRatioScorer
+    {
+        public int Score(string input2)
+        {
+            return ScoreFromChoice(input2);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private static int ScoreFromChoice(string value)
+    {
+        var start = "choice ".Length;
+        var end = value.IndexOf(' ', start);
+        return int.Parse(value.AsSpan(start, end - start)) % 100;
+    }
+}
+
+[MemoryDiagnoser]
+[RankColumn]
+public class ExtractSelectionFocusedBenchmarks
+{
+    private const int ChoiceCount = 100_000;
+    private const int Limit = 10;
+
+    private readonly ParallelOptions _parallelOptions = new() { MaxDegreeOfParallelism = 4 };
+    private readonly IRatioScorer _scorer = new CheapScorer();
+    private readonly ICachedRatioScorer _cachedScorer = new CheapCachedScorer();
+    private string[] _choices = null!;
+
+    [Params(0, 95)]
+    public int Cutoff { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _choices = ExtractSelectionOneBenchmarks.CreateChoices(ChoiceCount);
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Optimized_ExtractOne()
+    {
+        return ResultExtractor.ExtractOne(ExtractSelectionOneBenchmarks.Query, _choices, ExtractSelectionOneBenchmarks.Identity, _scorer, Cutoff);
+    }
+
+    [Benchmark(Baseline = true)]
+    public ExtractedResult<string> Legacy_ExtractOne()
+    {
+        return ExtractSelectionOneBenchmarks.LegacyExtractWithoutOrder(ExtractSelectionOneBenchmarks.Query, _choices, ExtractSelectionOneBenchmarks.Identity, _scorer, Cutoff).Max()!;
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Optimized_Cached_ExtractOne()
+    {
+        return ResultExtractor.Cached.ExtractOne(_choices, ExtractSelectionOneBenchmarks.Identity, _cachedScorer, Cutoff);
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Legacy_Cached_ExtractOne()
+    {
+        return ExtractSelectionOneBenchmarks.LegacyCachedExtractWithoutOrder(_choices, ExtractSelectionOneBenchmarks.Identity, _cachedScorer, Cutoff).Max()!;
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Optimized_Parallel_ExtractOne()
+    {
+        return ResultExtractor.Parallel.ExtractOne(ExtractSelectionOneBenchmarks.Query, _choices, ExtractSelectionOneBenchmarks.Identity, _scorer, Cutoff, _parallelOptions);
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Legacy_Parallel_ExtractOne()
+    {
+        return ExtractSelectionOneBenchmarks.LegacyParallelExtractWithoutOrder(ExtractSelectionOneBenchmarks.Query, _choices, ExtractSelectionOneBenchmarks.Identity, _scorer, Cutoff, _parallelOptions).Max()!;
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Optimized_ParallelCached_ExtractOne()
+    {
+        return ResultExtractor.Parallel.Cached.ExtractOne(_choices, ExtractSelectionOneBenchmarks.Identity, _cachedScorer, Cutoff, _parallelOptions);
+    }
+
+    [Benchmark]
+    public ExtractedResult<string> Legacy_ParallelCached_ExtractOne()
+    {
+        return ExtractSelectionOneBenchmarks.LegacyParallelCachedExtractWithoutOrder(_choices, ExtractSelectionOneBenchmarks.Identity, _cachedScorer, Cutoff, _parallelOptions).Max()!;
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Optimized_ExtractTop()
+    {
+        return ResultExtractor.ExtractTop(ExtractSelectionOneBenchmarks.Query, _choices, ExtractSelectionOneBenchmarks.Identity, _scorer, Limit, Cutoff).ToList();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Legacy_ExtractTop()
+    {
+        return ExtractSelectionOneBenchmarks.LegacyExtractWithoutOrder(ExtractSelectionOneBenchmarks.Query, _choices, ExtractSelectionOneBenchmarks.Identity, _scorer, Cutoff)
+            .MaxN(Limit)
+            .Reverse()
+            .ToList();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Optimized_Cached_ExtractTop()
+    {
+        return ResultExtractor.Cached.ExtractTop(_choices, ExtractSelectionOneBenchmarks.Identity, _cachedScorer, Limit, Cutoff).ToList();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Legacy_Cached_ExtractTop()
+    {
+        return ExtractSelectionOneBenchmarks.LegacyCachedExtractWithoutOrder(_choices, ExtractSelectionOneBenchmarks.Identity, _cachedScorer, Cutoff)
+            .MaxN(Limit)
+            .Reverse()
+            .ToList();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Optimized_Parallel_ExtractTop()
+    {
+        return ResultExtractor.Parallel.ExtractTop(ExtractSelectionOneBenchmarks.Query, _choices, ExtractSelectionOneBenchmarks.Identity, _scorer, Limit, Cutoff, _parallelOptions).ToList();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Legacy_Parallel_ExtractTop()
+    {
+        return ExtractSelectionOneBenchmarks.LegacyParallelExtractWithoutOrder(ExtractSelectionOneBenchmarks.Query, _choices, ExtractSelectionOneBenchmarks.Identity, _scorer, Cutoff, _parallelOptions)
+            .MaxN(Limit)
+            .Reverse()
+            .ToList();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Optimized_ParallelCached_ExtractTop()
+    {
+        return ResultExtractor.Parallel.Cached.ExtractTop(_choices, ExtractSelectionOneBenchmarks.Identity, _cachedScorer, Limit, Cutoff, _parallelOptions).ToList();
+    }
+
+    [Benchmark]
+    public List<ExtractedResult<string>> Legacy_ParallelCached_ExtractTop()
+    {
+        return ExtractSelectionOneBenchmarks.LegacyParallelCachedExtractWithoutOrder(_choices, ExtractSelectionOneBenchmarks.Identity, _cachedScorer, Cutoff, _parallelOptions)
+            .MaxN(Limit)
+            .Reverse()
+            .ToList();
+    }
+
+    private sealed class CheapScorer : IRatioScorer
+    {
+        public int Score(string input1, string input2)
+        {
+            return ScoreFromChoice(input2);
+        }
+
+        public int Score(string input1, string input2, Func<string, string> preprocessor)
+        {
+            return Score(preprocessor(input1), preprocessor(input2));
+        }
+    }
+
+    private sealed class CheapCachedScorer : ICachedRatioScorer
+    {
+        public int Score(string input2)
+        {
+            return ScoreFromChoice(input2);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private static int ScoreFromChoice(string value)
+    {
+        var start = "choice ".Length;
+        var end = value.IndexOf(' ', start);
+        return int.Parse(value.AsSpan(start, end - start)) % 100;
+    }
+}

--- a/FuzzySharp.Test/FuzzyTests/ExtractorSelectionTests.cs
+++ b/FuzzySharp.Test/FuzzyTests/ExtractorSelectionTests.cs
@@ -1,0 +1,379 @@
+using Raffinert.FuzzySharp.Extractor;
+using Raffinert.FuzzySharp.Extensions;
+using Raffinert.FuzzySharp.SimilarityRatio.Scorer;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Raffinert.FuzzySharp.Test.FuzzyTests;
+
+public class ExtractorSelectionTests
+{
+    private static readonly Func<string, string> IdentityProcessor = value => value;
+    private static readonly ParallelOptions TestParallelOptions = new() { MaxDegreeOfParallelism = 2 };
+
+    [Fact]
+    public void ExtractOne_EmptyChoices_ReturnsNull()
+    {
+        var scorer = new MapScorer();
+
+        Assert.Null(ResultExtractor.ExtractOne("query", [], IdentityProcessor, scorer));
+    }
+
+    [Fact]
+    public void ExtractOne_AllChoicesBelowCutoff_ReturnsNull()
+    {
+        var scorer = new MapScorer(("a", 10), ("b", 20));
+
+        Assert.Null(ResultExtractor.ExtractOne("query", ["a", "b"], IdentityProcessor, scorer, cutoff: 30));
+    }
+
+    [Fact]
+    public void ExtractOne_SelectsBest_UsesCutoffInclusively_AndKeepsOriginalIndex()
+    {
+        var choices = new[] { "below", "winner", "also-winner", "lower" };
+        var scorer = new MapScorer(("below", 10), ("winner", 80), ("also-winner", 80), ("lower", 70));
+
+        var result = ResultExtractor.ExtractOne("query", choices, IdentityProcessor, scorer, cutoff: 80);
+
+        AssertResult(result, "winner", 80, 1);
+    }
+
+    [Fact]
+    public void ExtractOne_GenericValueChoices_WithStringQuery_UsesExtractor()
+    {
+        var choices = new[] { new Choice("below"), new Choice("winner"), new Choice("lower") };
+        var scorer = new MapScorer(("below", 20), ("winner", 90), ("lower", 80));
+
+        var result = ResultExtractor.ExtractOne("query", choices, static choice => choice.Name, IdentityProcessor, scorer, cutoff: 50);
+
+        Assert.Same(choices[1], result.Value);
+        Assert.Equal(90, result.Score);
+        Assert.Equal(1, result.Index);
+    }
+
+    [Fact]
+    public void ExtractOne_GenericQueryAndChoices_UsesExtractor()
+    {
+        var query = new Choice("query");
+        var choices = new[] { new Choice("lower"), new Choice("winner") };
+        var scorer = new MapScorer(("lower", 60), ("winner", 95));
+
+        var result = ResultExtractor.ExtractOne(query, choices, static choice => choice.Name, IdentityProcessor, scorer);
+
+        Assert.Same(choices[1], result.Value);
+        Assert.Equal(95, result.Score);
+        Assert.Equal(1, result.Index);
+    }
+
+    [Fact]
+    public void ExtractOne_CachedSequential_Parallel_AndParallelCached_PreserveBestTieAndIndex()
+    {
+        var choices = new[] { "below", "first-best", "lower", "second-best" };
+        var scorer = new MapScorer(("below", 10), ("first-best", 88), ("lower", 70), ("second-best", 88));
+        var cachedScorer = new CachedMapScorer(("below", 10), ("first-best", 88), ("lower", 70), ("second-best", 88));
+
+        AssertResult(ResultExtractor.Cached.ExtractOne(choices, IdentityProcessor, cachedScorer), "first-best", 88, 1);
+        AssertResult(ResultExtractor.Parallel.ExtractOne("query", choices, IdentityProcessor, scorer, parallelOptions: TestParallelOptions), "first-best", 88, 1);
+        AssertResult(ResultExtractor.Parallel.Cached.ExtractOne(choices, IdentityProcessor, cachedScorer, parallelOptions: TestParallelOptions), "first-best", 88, 1);
+    }
+
+    [Fact]
+    public void ExtractOne_OneShotEnumerable_IsEnumeratedOnce()
+    {
+        var choices = new OneShotEnumerable<string>(["a", "winner", "b"]);
+        var scorer = new MapScorer(("a", 10), ("winner", 90), ("b", 20));
+
+        var result = ResultExtractor.ExtractOne("query", choices, IdentityProcessor, scorer);
+
+        AssertResult(result, "winner", 90, 1);
+    }
+
+    [Fact]
+    public void ExtractOne_InvokesProcessorExtractorAndScorerOncePerInput()
+    {
+        var query = new Choice("query");
+        var choices = new[] { new Choice("a"), new Choice("winner"), new Choice("b") };
+        var scorer = new MapScorer(("a", 10), ("winner", 90), ("b", 20));
+        var extractorCalls = 0;
+        var processorCalls = 0;
+
+        var result = ResultExtractor.ExtractOne(
+            query,
+            choices,
+            choice =>
+            {
+                Interlocked.Increment(ref extractorCalls);
+                return choice.Name;
+            },
+            value =>
+            {
+                Interlocked.Increment(ref processorCalls);
+                return value;
+            },
+            scorer);
+
+        Assert.Same(choices[1], result.Value);
+        Assert.Equal(4, extractorCalls);
+        Assert.Equal(4, processorCalls);
+        Assert.Equal(3, scorer.ScoreCalls);
+    }
+
+    [Fact]
+    public void ExtractTop_EmptyAndNoAccepted_ReturnEmpty()
+    {
+        var scorer = new MapScorer(("a", 10), ("b", 20));
+
+        Assert.Empty(ResultExtractor.ExtractTop("query", [], IdentityProcessor, scorer, limit: 5));
+        Assert.Empty(ResultExtractor.ExtractTop("query", ["a", "b"], IdentityProcessor, scorer, limit: 5, cutoff: 30));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(10)]
+    public void ExtractTop_SequentialMatchesLegacyTopNIncludingTies(int limit)
+    {
+        var choices = new[] { "below", "tie-a", "mid", "tie-b", "edge", "top", "tie-c" };
+        var scorer = new MapScorer(("below", 10), ("tie-a", 80), ("mid", 70), ("tie-b", 80), ("edge", 60), ("top", 95), ("tie-c", 80));
+
+        var expected = LegacyTop("query", choices, IdentityProcessor, scorer, limit, cutoff: 60);
+        var actual = ResultExtractor.ExtractTop("query", choices, IdentityProcessor, scorer, limit, cutoff: 60);
+
+        AssertSameResults(expected, actual);
+    }
+
+    [Fact]
+    public void ExtractTop_GenericCachedParallelVariantsMatchLegacyTopN()
+    {
+        var choices = new[] { new Choice("below"), new Choice("tie-a"), new Choice("mid"), new Choice("tie-b"), new Choice("top") };
+        var scorer = new MapScorer(("below", 10), ("tie-a", 80), ("mid", 70), ("tie-b", 80), ("top", 95));
+        var cachedScorer = new CachedMapScorer(("below", 10), ("tie-a", 80), ("mid", 70), ("tie-b", 80), ("top", 95));
+        var expected = LegacyTop("query", choices, static choice => choice.Name, IdentityProcessor, scorer, limit: 3, cutoff: 70);
+
+        AssertSameResults(expected, ResultExtractor.ExtractTop("query", choices, static choice => choice.Name, IdentityProcessor, scorer, limit: 3, cutoff: 70));
+        AssertSameResults(expected, ResultExtractor.Cached.ExtractTop(choices, static choice => choice.Name, IdentityProcessor, cachedScorer, limit: 3, cutoff: 70));
+        AssertSameResults(expected, ResultExtractor.Parallel.ExtractTop("query", choices, static choice => choice.Name, IdentityProcessor, scorer, limit: 3, cutoff: 70, parallelOptions: TestParallelOptions));
+        AssertSameResults(expected, ResultExtractor.Parallel.Cached.ExtractTop(choices, static choice => choice.Name, IdentityProcessor, cachedScorer, limit: 3, cutoff: 70, parallelOptions: TestParallelOptions));
+    }
+
+    [Fact]
+    public void ExtractTop_LimitZeroAndNegative_PreserveLegacyBehavior()
+    {
+        var scorer = new MapScorer(("accepted", 50));
+        var choices = new[] { "accepted" };
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ResultExtractor.ExtractTop("query", choices, IdentityProcessor, scorer, limit: 0).ToList());
+        Assert.Throws<InvalidOperationException>(() =>
+            ResultExtractor.ExtractTop("query", choices, IdentityProcessor, scorer, limit: -1).ToList());
+        Assert.Empty(ResultExtractor.ExtractTop("query", choices, IdentityProcessor, scorer, limit: 0, cutoff: 90));
+    }
+
+    [Fact]
+    public void ExtractTop_SequentialIsDeferredAndRepeatedEnumerationScoresAgain()
+    {
+        var choices = new[] { "a", "winner", "b" };
+        var scorer = new MapScorer(("a", 10), ("winner", 90), ("b", 20));
+        var processorCalls = 0;
+        string Processor(string value)
+        {
+            processorCalls++;
+            return value;
+        }
+
+        var results = ResultExtractor.ExtractTop("query", choices, Processor, scorer, limit: 2);
+
+        Assert.Equal(0, processorCalls);
+        Assert.Equal(0, scorer.ScoreCalls);
+
+        Assert.Equal(2, results.ToList().Count);
+        Assert.Equal(4, processorCalls);
+        Assert.Equal(3, scorer.ScoreCalls);
+
+        Assert.Equal(2, results.ToList().Count);
+        Assert.Equal(8, processorCalls);
+        Assert.Equal(6, scorer.ScoreCalls);
+    }
+
+    [Fact]
+    public void ExtractTop_ParallelScoresEagerlyButSelectsOnEnumeration()
+    {
+        var choices = new[] { "a", "winner", "b" };
+        var scorer = new MapScorer(("a", 10), ("winner", 90), ("b", 20));
+        var processorCalls = 0;
+        string Processor(string value)
+        {
+            Interlocked.Increment(ref processorCalls);
+            return value;
+        }
+
+        var results = ResultExtractor.Parallel.ExtractTop("query", choices, Processor, scorer, limit: 2, parallelOptions: TestParallelOptions);
+
+        Assert.Equal(4, processorCalls);
+        Assert.Equal(3, scorer.ScoreCalls);
+        Assert.Equal(2, results.ToList().Count);
+    }
+
+    private static List<ExtractedResult<string>> LegacyTop(
+        string query,
+        IEnumerable<string> choices,
+        Func<string, string> processor,
+        IRatioScorer scorer,
+        int limit,
+        int cutoff)
+    {
+        return LegacyWithoutOrder(query, choices, static value => value, processor, scorer, cutoff)
+            .MaxN(limit)
+            .Reverse()
+            .ToList();
+    }
+
+    private static List<ExtractedResult<T>> LegacyTop<T>(
+        string query,
+        IEnumerable<T> choices,
+        Func<T, string> extractor,
+        Func<string, string> processor,
+        IRatioScorer scorer,
+        int limit,
+        int cutoff)
+    {
+        return LegacyWithoutOrder(query, choices, extractor, processor, scorer, cutoff)
+            .MaxN(limit)
+            .Reverse()
+            .ToList();
+    }
+
+    private static IEnumerable<ExtractedResult<T>> LegacyWithoutOrder<T>(
+        string query,
+        IEnumerable<T> choices,
+        Func<T, string> extractor,
+        Func<string, string> processor,
+        IRatioScorer scorer,
+        int cutoff)
+    {
+        var index = 0;
+        var processedQuery = processor(query);
+
+        foreach (var choice in choices)
+        {
+            var score = scorer.Score(processedQuery, processor(extractor(choice)));
+            if (score >= cutoff)
+            {
+                yield return new ExtractedResult<T>(choice, score, index);
+            }
+
+            index++;
+        }
+    }
+
+    private static void AssertSameResults<T>(IEnumerable<ExtractedResult<T>> expected, IEnumerable<ExtractedResult<T>> actual)
+    {
+        var expectedList = expected.ToList();
+        var actualList = actual.ToList();
+
+        Assert.Equal(expectedList.Count, actualList.Count);
+        for (var i = 0; i < expectedList.Count; i++)
+        {
+            Assert.Equal(expectedList[i].Value, actualList[i].Value);
+            Assert.Equal(expectedList[i].Score, actualList[i].Score);
+            Assert.Equal(expectedList[i].Index, actualList[i].Index);
+        }
+    }
+
+    private static void AssertResult(ExtractedResult<string> result, string value, int score, int index)
+    {
+        Assert.Equal(value, result.Value);
+        Assert.Equal(score, result.Score);
+        Assert.Equal(index, result.Index);
+    }
+
+    private sealed class Choice
+    {
+        public Choice(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+
+    public sealed class MapScorer : IRatioScorer
+    {
+        private readonly Dictionary<string, int> _scores;
+        private int _scoreCalls;
+
+        public MapScorer()
+            : this([])
+        {
+        }
+
+        public MapScorer(params (string Value, int Score)[] scores)
+        {
+            _scores = scores.ToDictionary(score => score.Value, score => score.Score);
+        }
+
+        public int ScoreCalls => _scoreCalls;
+
+        public int Score(string input1, string input2)
+        {
+            Interlocked.Increment(ref _scoreCalls);
+            return _scores.TryGetValue(input2, out var score) ? score : 0;
+        }
+
+        public int Score(string input1, string input2, Func<string, string> preprocessor)
+        {
+            return Score(preprocessor(input1), preprocessor(input2));
+        }
+    }
+
+    private sealed class CachedMapScorer : ICachedRatioScorer
+    {
+        private readonly Dictionary<string, int> _scores;
+
+        public CachedMapScorer(params (string Value, int Score)[] scores)
+        {
+            _scores = scores.ToDictionary(score => score.Value, score => score.Score);
+        }
+
+        public int Score(string input2)
+        {
+            return _scores.TryGetValue(input2, out var score) ? score : 0;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class OneShotEnumerable<T> : IEnumerable<T>
+    {
+        private readonly IEnumerable<T> _items;
+        private int _enumerated;
+
+        public OneShotEnumerable(IEnumerable<T> items)
+        {
+            _items = items;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            if (Interlocked.Exchange(ref _enumerated, 1) == 1)
+            {
+                throw new InvalidOperationException("Sequence was enumerated more than once.");
+            }
+
+            return _items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/FuzzySharp/Extractor/ResultExtractor.Cached.cs
+++ b/FuzzySharp/Extractor/ResultExtractor.Cached.cs
@@ -1,4 +1,3 @@
-﻿using Raffinert.FuzzySharp.Extensions;
 using Raffinert.FuzzySharp.SimilarityRatio.Scorer;
 using System;
 using System.Collections.Generic;
@@ -42,12 +41,12 @@ public static partial class ResultExtractor
 
         public static ExtractedResult<T> ExtractOne<T>(IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, ICachedRatioScorer scorer, int cutoff = 0)
         {
-            return ExtractWithoutOrder(choices, extractor, processor, scorer, cutoff).Max();
+            return ExtractOneCore(choices, choice => scorer.Score(processor(extractor(choice))), cutoff);
         }
 
         public static ExtractedResult<string> ExtractOne(IEnumerable<string> choices, Func<string, string> processor, ICachedRatioScorer scorer, int cutoff = 0)
         {
-            return ExtractWithoutOrder(choices, processor, scorer, cutoff).Max();
+            return ExtractOneCore(choices, choice => scorer.Score(processor(choice)), cutoff);
         }
 
         public static IEnumerable<ExtractedResult<T>> ExtractSorted<T>(IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, ICachedRatioScorer scorer, int cutoff = 0)
@@ -62,12 +61,12 @@ public static partial class ResultExtractor
 
         public static IEnumerable<ExtractedResult<T>> ExtractTop<T>(IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, ICachedRatioScorer scorer, int limit, int cutoff = 0)
         {
-            return ExtractWithoutOrder(choices, extractor, processor, scorer, cutoff).MaxN(limit).Reverse();
+            return ExtractTopCore(choices, choice => scorer.Score(processor(extractor(choice))), limit, cutoff);
         }
 
         public static IEnumerable<ExtractedResult<string>> ExtractTop(IEnumerable<string> choices, Func<string, string> processor, ICachedRatioScorer scorer, int limit, int cutoff = 0)
         {
-            return ExtractWithoutOrder(choices, processor, scorer, cutoff).MaxN(limit).Reverse();
+            return ExtractTopCore(choices, choice => scorer.Score(processor(choice)), limit, cutoff);
         }
     }
 }

--- a/FuzzySharp/Extractor/ResultExtractor.Parallel.Cached.cs
+++ b/FuzzySharp/Extractor/ResultExtractor.Parallel.Cached.cs
@@ -1,4 +1,3 @@
-﻿using Raffinert.FuzzySharp.Extensions;
 using Raffinert.FuzzySharp.SimilarityRatio.Scorer;
 using System;
 using System.Collections.Generic;
@@ -47,12 +46,14 @@ public static partial class ResultExtractor
 
             public static ExtractedResult<T> ExtractOne<T>(IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, ICachedRatioScorer calculator, int cutoff = 0, ParallelOptions parallelOptions = null)
             {
-                return ExtractWithoutOrder(choices, extractor, processor, calculator, cutoff, parallelOptions).Max();
+                var materializedChoices = choices.ToList();
+                return ExtractOneParallelCore(materializedChoices, choice => calculator.Score(processor(extractor(choice))), cutoff, parallelOptions);
             }
 
             public static ExtractedResult<string> ExtractOne(IEnumerable<string> choices, Func<string, string> processor, ICachedRatioScorer calculator, int cutoff = 0, ParallelOptions parallelOptions = null)
             {
-                return ExtractWithoutOrder(choices, processor, calculator, cutoff, parallelOptions).Max();
+                var materializedChoices = choices.ToList();
+                return ExtractOneParallelCore(materializedChoices, choice => calculator.Score(processor(choice)), cutoff, parallelOptions);
             }
 
             public static IEnumerable<ExtractedResult<T>> ExtractSorted<T>(IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, ICachedRatioScorer calculator, int cutoff = 0, ParallelOptions parallelOptions = null)
@@ -67,12 +68,16 @@ public static partial class ResultExtractor
 
             public static IEnumerable<ExtractedResult<T>> ExtractTop<T>(IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, ICachedRatioScorer calculator, int limit, int cutoff = 0, ParallelOptions parallelOptions = null)
             {
-                return ExtractWithoutOrder(choices, extractor, processor, calculator, cutoff, parallelOptions).MaxN(limit).Reverse();
+                var materializedChoices = choices.ToList();
+                var scores = ScoreParallel(materializedChoices, choice => calculator.Score(processor(extractor(choice))), parallelOptions);
+                return ExtractTopParallelCore(materializedChoices, scores, limit, cutoff);
             }
 
             public static IEnumerable<ExtractedResult<string>> ExtractTop(IEnumerable<string> choices, Func<string, string> processor, ICachedRatioScorer calculator, int limit, int cutoff = 0, ParallelOptions parallelOptions = null)
             {
-                return ExtractWithoutOrder(choices, processor, calculator, cutoff, parallelOptions).MaxN(limit).Reverse();
+                var materializedChoices = choices.ToList();
+                var scores = ScoreParallel(materializedChoices, choice => calculator.Score(processor(choice)), parallelOptions);
+                return ExtractTopParallelCore(materializedChoices, scores, limit, cutoff);
             }
         }
     }

--- a/FuzzySharp/Extractor/ResultExtractor.Parallel.cs
+++ b/FuzzySharp/Extractor/ResultExtractor.Parallel.cs
@@ -1,5 +1,5 @@
-﻿using Raffinert.FuzzySharp.Extensions;
 using Raffinert.FuzzySharp.SimilarityRatio.Scorer;
+using Raffinert.FuzzySharp.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,6 +13,87 @@ public static partial class ResultExtractor
 
     public static partial class Parallel
     {
+        private static ExtractedResult<T> ExtractOneParallelCore<T>(
+            IList<T> choices,
+            Func<T, int> scoreSelector,
+            int cutoff,
+            ParallelOptions parallelOptions)
+        {
+            var sync = new object();
+            var globalBest = new BestCandidate<T>();
+
+            System.Threading.Tasks.Parallel.For(
+                0,
+                choices.Count,
+                parallelOptions ?? DefaultParallelOptions,
+                () => new BestCandidate<T>(),
+                (index, _, localBest) =>
+                {
+                    var choice = choices[index];
+                    localBest.Consider(choice, scoreSelector(choice), index, cutoff);
+                    return localBest;
+                },
+                localBest =>
+                {
+                    if (!localBest.HasValue)
+                    {
+                        return;
+                    }
+
+                    lock (sync)
+                    {
+                        globalBest.Consider(localBest);
+                    }
+                });
+
+            if (!globalBest.HasValue)
+            {
+                return Enumerable.Empty<ExtractedResult<T>>().Max();
+            }
+
+            var candidate = globalBest.Candidate;
+            return new ExtractedResult<T>(candidate.Value, candidate.Score, candidate.Index);
+        }
+
+        private static IEnumerable<ExtractedResult<T>> ExtractTopParallelCore<T>(
+            IList<T> choices,
+            int[] scores,
+            int limit,
+            int cutoff)
+        {
+            var heap = new MinHeap<ScoredCandidate<T>>(ScoredCandidateComparer<T>.Instance);
+            var comparer = ScoredCandidateComparer<T>.Instance;
+
+            for (var index = 0; index < scores.Length; index++)
+            {
+                var score = scores[index];
+                if (score >= cutoff)
+                {
+                    AddTopCandidate(heap, comparer, new ScoredCandidate<T>(choices[index], score, index), limit);
+                }
+            }
+
+            foreach (var result in CreateTopResults(heap))
+            {
+                yield return result;
+            }
+        }
+
+        private static int[] ScoreParallel<T>(
+            IList<T> choices,
+            Func<T, int> scoreSelector,
+            ParallelOptions parallelOptions)
+        {
+            var scores = new int[choices.Count];
+
+            System.Threading.Tasks.Parallel.For(0, choices.Count, parallelOptions ?? DefaultParallelOptions, index =>
+            {
+                scores[index] = scoreSelector(choices[index]);
+            });
+
+            return scores;
+        }
+
         public static IEnumerable<ExtractedResult<T>> ExtractWithoutOrder<T>(string query, IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, IRatioScorer scorer, int cutoff = 0, ParallelOptions parallelOptions = null)
         {
             var materializedChoices = choices.ToList();
@@ -51,20 +132,26 @@ public static partial class ResultExtractor
         {
             return ExtractWithoutOrder(extractor(query), choices, extractor, processor, scorer, cutoff, parallelOptions);
         }
-        
+
         public static ExtractedResult<T> ExtractOne<T>(T query, IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, IRatioScorer calculator, int cutoff = 0, ParallelOptions parallelOptions = null)
         {
-            return ExtractWithoutOrder(query, choices, extractor, processor, calculator, cutoff, parallelOptions).Max();
+            var materializedChoices = choices.ToList();
+            var processedQuery = processor(extractor(query));
+            return ExtractOneParallelCore(materializedChoices, choice => calculator.Score(processedQuery, processor(extractor(choice))), cutoff, parallelOptions);
         }
 
         public static ExtractedResult<string> ExtractOne(string query, IEnumerable<string> choices, Func<string, string> processor, IRatioScorer calculator, int cutoff = 0, ParallelOptions parallelOptions = null)
         {
-            return ExtractWithoutOrder(query, choices, processor, calculator, cutoff, parallelOptions).Max();
+            var materializedChoices = choices.ToList();
+            var processedQuery = processor(query);
+            return ExtractOneParallelCore(materializedChoices, choice => calculator.Score(processedQuery, processor(choice)), cutoff, parallelOptions);
         }
 
         public static ExtractedResult<T> ExtractOne<T>(string query, IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, IRatioScorer calculator, int cutoff = 0, ParallelOptions parallelOptions = null)
         {
-            return ExtractWithoutOrder(query, choices, extractor, processor, calculator, cutoff, parallelOptions).Max();
+            var materializedChoices = choices.ToList();
+            var processedQuery = processor(query);
+            return ExtractOneParallelCore(materializedChoices, choice => calculator.Score(processedQuery, processor(extractor(choice))), cutoff, parallelOptions);
         }
 
         public static IEnumerable<ExtractedResult<T>> ExtractSorted<T>(T query, IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, IRatioScorer calculator, int cutoff = 0, ParallelOptions parallelOptions = null)
@@ -84,17 +171,26 @@ public static partial class ResultExtractor
 
         public static IEnumerable<ExtractedResult<T>> ExtractTop<T>(T query, IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, IRatioScorer calculator, int limit, int cutoff = 0, ParallelOptions parallelOptions = null)
         {
-            return ExtractWithoutOrder(query, choices, extractor, processor, calculator, cutoff, parallelOptions).MaxN(limit).Reverse();
+            var materializedChoices = choices.ToList();
+            var processedQuery = processor(extractor(query));
+            var scores = ScoreParallel(materializedChoices, choice => calculator.Score(processedQuery, processor(extractor(choice))), parallelOptions);
+            return ExtractTopParallelCore(materializedChoices, scores, limit, cutoff);
         }
 
         public static IEnumerable<ExtractedResult<string>> ExtractTop(string query, IEnumerable<string> choices, Func<string, string> processor, IRatioScorer calculator, int limit, int cutoff = 0, ParallelOptions parallelOptions = null)
         {
-            return ExtractWithoutOrder(query, choices, processor, calculator, cutoff, parallelOptions).MaxN(limit).Reverse();
+            var materializedChoices = choices.ToList();
+            var processedQuery = processor(query);
+            var scores = ScoreParallel(materializedChoices, choice => calculator.Score(processedQuery, processor(choice)), parallelOptions);
+            return ExtractTopParallelCore(materializedChoices, scores, limit, cutoff);
         }
 
         public static IEnumerable<ExtractedResult<T>> ExtractTop<T>(string query, IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, IRatioScorer calculator, int limit, int cutoff = 0, ParallelOptions parallelOptions = null)
         {
-            return ExtractWithoutOrder(query, choices, extractor, processor, calculator, cutoff, parallelOptions).MaxN(limit).Reverse();
+            var materializedChoices = choices.ToList();
+            var processedQuery = processor(query);
+            var scores = ScoreParallel(materializedChoices, choice => calculator.Score(processedQuery, processor(extractor(choice))), parallelOptions);
+            return ExtractTopParallelCore(materializedChoices, scores, limit, cutoff);
         }
     }
 }

--- a/FuzzySharp/Extractor/ResultExtractor.Parallel.cs
+++ b/FuzzySharp/Extractor/ResultExtractor.Parallel.cs
@@ -48,7 +48,7 @@ public static partial class ResultExtractor
 
             if (!globalBest.HasValue)
             {
-                return Enumerable.Empty<ExtractedResult<T>>().Max();
+                return null;
             }
 
             var candidate = globalBest.Candidate;

--- a/FuzzySharp/Extractor/ResultExtractor.Parallel.cs
+++ b/FuzzySharp/Extractor/ResultExtractor.Parallel.cs
@@ -35,24 +35,18 @@ public static partial class ResultExtractor
                 },
                 localBest =>
                 {
-                    if (!localBest.HasValue)
+                    if (localBest.HasValue)
                     {
-                        return;
-                    }
-
-                    lock (sync)
-                    {
-                        globalBest.Consider(localBest);
+                        lock (sync)
+                        {
+                            globalBest.Consider(localBest);
+                        }
                     }
                 });
 
-            if (!globalBest.HasValue)
-            {
-                return null;
-            }
-
-            var candidate = globalBest.Candidate;
-            return new ExtractedResult<T>(candidate.Value, candidate.Score, candidate.Index);
+            return globalBest.HasValue 
+                ? new ExtractedResult<T>(globalBest.Candidate.Value, globalBest.Candidate.Score, globalBest.Candidate.Index) 
+                : null;
         }
 
         private static IEnumerable<ExtractedResult<T>> ExtractTopParallelCore<T>(

--- a/FuzzySharp/Extractor/ResultExtractor.cs
+++ b/FuzzySharp/Extractor/ResultExtractor.cs
@@ -47,8 +47,8 @@ public static partial class ResultExtractor
         int limit,
         int cutoff)
     {
-        var heap = new MinHeap<ScoredCandidate<T>>(ScoredCandidateComparer<T>.Instance);
         var comparer = ScoredCandidateComparer<T>.Instance;
+        var heap = new MinHeap<ScoredCandidate<T>>(comparer);
         var index = 0;
 
         foreach (var choice in choices)

--- a/FuzzySharp/Extractor/ResultExtractor.cs
+++ b/FuzzySharp/Extractor/ResultExtractor.cs
@@ -35,7 +35,7 @@ public static partial class ResultExtractor
 
         if (!hasBest)
         {
-            return Enumerable.Empty<ExtractedResult<T>>().Max();
+            return null;
         }
 
         return new ExtractedResult<T>(bestValue, bestScore, bestIndex);

--- a/FuzzySharp/Extractor/ResultExtractor.cs
+++ b/FuzzySharp/Extractor/ResultExtractor.cs
@@ -1,5 +1,5 @@
-﻿using Raffinert.FuzzySharp.Extensions;
 using Raffinert.FuzzySharp.SimilarityRatio.Scorer;
+using Raffinert.FuzzySharp.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +8,96 @@ namespace Raffinert.FuzzySharp.Extractor;
 
 public static partial class ResultExtractor
 {
+    private static ExtractedResult<T> ExtractOneCore<T>(
+        IEnumerable<T> choices,
+        Func<T, int> scoreSelector,
+        int cutoff)
+    {
+        var index = 0;
+        var bestIndex = 0;
+        var bestScore = 0;
+        T bestValue = default;
+        var hasBest = false;
+
+        foreach (var choice in choices)
+        {
+            var score = scoreSelector(choice);
+            if (score >= cutoff && (!hasBest || score > bestScore))
+            {
+                bestValue = choice;
+                bestScore = score;
+                bestIndex = index;
+                hasBest = true;
+            }
+
+            index++;
+        }
+
+        if (!hasBest)
+        {
+            return Enumerable.Empty<ExtractedResult<T>>().Max();
+        }
+
+        return new ExtractedResult<T>(bestValue, bestScore, bestIndex);
+    }
+
+    private static IEnumerable<ExtractedResult<T>> ExtractTopCore<T>(
+        IEnumerable<T> choices,
+        Func<T, int> scoreSelector,
+        int limit,
+        int cutoff)
+    {
+        var heap = new MinHeap<ScoredCandidate<T>>(ScoredCandidateComparer<T>.Instance);
+        var comparer = ScoredCandidateComparer<T>.Instance;
+        var index = 0;
+
+        foreach (var choice in choices)
+        {
+            var score = scoreSelector(choice);
+            if (score >= cutoff)
+            {
+                AddTopCandidate(heap, comparer, new ScoredCandidate<T>(choice, score, index), limit);
+            }
+
+            index++;
+        }
+
+        foreach (var result in CreateTopResults(heap))
+        {
+            yield return result;
+        }
+    }
+
+    private static void AddTopCandidate<T>(
+        MinHeap<ScoredCandidate<T>> heap,
+        Comparer<ScoredCandidate<T>> comparer,
+        ScoredCandidate<T> candidate,
+        int limit)
+    {
+        if (heap.Count < limit)
+        {
+            heap.Add(candidate);
+        }
+        else if (comparer.Compare(candidate, heap.GetMin()) > 0)
+        {
+            heap.ExtractDominating();
+            heap.Add(candidate);
+        }
+    }
+
+    private static IEnumerable<ExtractedResult<T>> CreateTopResults<T>(MinHeap<ScoredCandidate<T>> heap)
+    {
+        var results = new ExtractedResult<T>[heap.Count];
+
+        for (var i = results.Length - 1; i >= 0; i--)
+        {
+            var candidate = heap.ExtractDominating();
+            results[i] = new ExtractedResult<T>(candidate.Value, candidate.Score, candidate.Index);
+        }
+
+        return results;
+    }
+
     public static IEnumerable<ExtractedResult<T>> ExtractWithoutOrder<T>(string query, IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, IRatioScorer scorer, int cutoff = 0)
     {
         int index = 0;
@@ -47,20 +137,26 @@ public static partial class ResultExtractor
         var extracted = extractor(query);
         return ExtractWithoutOrder(extracted, choices, extractor, processor, scorer, cutoff);
     }
-            
+
     public static ExtractedResult<T> ExtractOne<T>(T query, IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, IRatioScorer scorer, int cutoff = 0)
     {
-        return ExtractWithoutOrder(query, choices, extractor, processor, scorer, cutoff).Max();
+        processor ??= Process.DefaultStringProcessor;
+        var processedQuery = processor(extractor(query));
+        return ExtractOneCore(choices, choice => scorer.Score(processedQuery, processor(extractor(choice))), cutoff);
     }
 
     public static ExtractedResult<string> ExtractOne(string query, IEnumerable<string> choices, Func<string, string> processor, IRatioScorer scorer, int cutoff = 0)
     {
-        return ExtractWithoutOrder(query, choices, processor, scorer, cutoff).Max();
+        processor ??= Process.DefaultStringProcessor;
+        var processedQuery = processor(query);
+        return ExtractOneCore(choices, choice => scorer.Score(processedQuery, processor(choice)), cutoff);
     }
 
     public static ExtractedResult<T> ExtractOne<T>(string query, IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, IRatioScorer scorer, int cutoff = 0)
     {
-        return ExtractWithoutOrder(query, choices, extractor, processor, scorer, cutoff).Max();
+        processor ??= Process.DefaultStringProcessor;
+        var processedQuery = processor(query);
+        return ExtractOneCore(choices, choice => scorer.Score(processedQuery, processor(extractor(choice))), cutoff);
     }
 
     public static IEnumerable<ExtractedResult<T>> ExtractSorted<T>(T query, IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, IRatioScorer scorer, int cutoff = 0)
@@ -80,16 +176,37 @@ public static partial class ResultExtractor
 
     public static IEnumerable<ExtractedResult<T>> ExtractTop<T>(T query, IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, IRatioScorer scorer, int limit, int cutoff = 0)
     {
-        return ExtractWithoutOrder(query, choices, extractor, processor, scorer, cutoff).MaxN(limit).Reverse();
+        var extracted = extractor(query);
+        return ExtractTop(extracted, choices, extractor, processor, scorer, limit, cutoff);
     }
 
     public static IEnumerable<ExtractedResult<string>> ExtractTop(string query, IEnumerable<string> choices, Func<string, string> processor, IRatioScorer scorer, int limit, int cutoff = 0)
     {
-        return ExtractWithoutOrder(query, choices, processor, scorer, cutoff).MaxN(limit).Reverse();
+        processor ??= Process.DefaultStringProcessor;
+        return ExtractTopIterator();
+
+        IEnumerable<ExtractedResult<string>> ExtractTopIterator()
+        {
+            var processedQuery = processor(query);
+            foreach (var result in ExtractTopCore(choices, choice => scorer.Score(processedQuery, processor(choice)), limit, cutoff))
+            {
+                yield return result;
+            }
+        }
     }
 
     public static IEnumerable<ExtractedResult<T>> ExtractTop<T>(string query, IEnumerable<T> choices, Func<T, string> extractor, Func<string, string> processor, IRatioScorer scorer, int limit, int cutoff = 0)
     {
-        return ExtractWithoutOrder(query, choices, extractor, processor, scorer, cutoff).MaxN(limit).Reverse();
+        processor ??= Process.DefaultStringProcessor;
+        return ExtractTopIterator();
+
+        IEnumerable<ExtractedResult<T>> ExtractTopIterator()
+        {
+            var processedQuery = processor(query);
+            foreach (var result in ExtractTopCore(choices, choice => scorer.Score(processedQuery, processor(extractor(choice))), limit, cutoff))
+            {
+                yield return result;
+            }
+        }
     }
 }

--- a/FuzzySharp/Extractor/ScoredCandidate.cs
+++ b/FuzzySharp/Extractor/ScoredCandidate.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+
+namespace Raffinert.FuzzySharp.Extractor;
+
+internal readonly struct ScoredCandidate<T>(T value, int score, int index)
+{
+    public T Value { get; } = value;
+
+    public int Score { get; } = score;
+
+    public int Index { get; } = index;
+}
+
+internal sealed class ScoredCandidateComparer<T> : Comparer<ScoredCandidate<T>>
+{
+    public static ScoredCandidateComparer<T> Instance { get; } = new();
+
+    public override int Compare(ScoredCandidate<T> x, ScoredCandidate<T> y)
+    {
+        return x.Score.CompareTo(y.Score);
+    }
+}
+
+internal struct BestCandidate<T>
+{
+    public ScoredCandidate<T> Candidate { get; private set; }
+
+    public bool HasValue { get; private set; }
+
+    public void Consider(T value, int score, int index, int cutoff)
+    {
+        if (score < cutoff)
+        {
+            return;
+        }
+
+        if (!HasValue || score > Candidate.Score || (score == Candidate.Score && index < Candidate.Index))
+        {
+            Candidate = new ScoredCandidate<T>(value, score, index);
+            HasValue = true;
+        }
+    }
+
+    public void Consider(BestCandidate<T> other)
+    {
+        if (other.HasValue)
+        {
+            Consider(other.Candidate.Value, other.Candidate.Score, other.Candidate.Index, int.MinValue);
+        }
+    }
+}

--- a/FuzzySharp/FuzzySharp.csproj
+++ b/FuzzySharp/FuzzySharp.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <FileVersion>5.0.2.0</FileVersion>
-    <Version>5.0.2</Version>
-    <PackageVersion>5.0.2</PackageVersion>
-    <AssemblyVersion>5.0.2.0</AssemblyVersion>
-    <FileVersion>5.0.2.0</FileVersion>
-    <Version>5.0.2</Version>
-    <PackageVersion>5.0.2</PackageVersion>
-    <Authors>Jacob Bayer;Yevhen Cherkes</Authors>
+    <FileVersion>5.0.3.0</FileVersion>
+    <Version>5.0.3</Version>
+    <PackageVersion>5.0.3</PackageVersion>
+    <AssemblyVersion>5.0.3.0</AssemblyVersion>
+    <FileVersion>5.0.3.0</FileVersion>
+    <Version>5.0.3</Version>
+    <PackageVersion>5.0.3</PackageVersion>
+    <Authors>Yevhen Cherkes;Jacob Bayer</Authors>
     <Company />
     <Description>
         Fuzzy string matcher based on FuzzyWuzzy algorithm from SeatGeek and RapidFuzz python and cpp libraries from Max Bachmann.

--- a/docs/optimize-extract-methods-review.md
+++ b/docs/optimize-extract-methods-review.md
@@ -23,15 +23,13 @@ Refactored `ResultExtractor` to eliminate double-iteration from LINQ `.Max()` / 
 
 ## Findings
 
-### 🔴 HIGH — Empty sequence throws on no-match (`ResultExtractor.cs:38`, `.Parallel.cs:51`)
+### 🟡 MEDIUM — Silent null return on no-match (`ResultExtractor.cs:38`, `.Parallel.cs:51`)
 
 ```csharp
 return Enumerable.Empty<ExtractedResult<T>>().Max();
 ```
 
-When no candidates meet the cutoff, this calls `.Max()` on an empty `IEnumerable` and throws `InvalidOperationException`. This is a **pre-existing bug** (old code did the same), so functionally unchanged — but should be addressed in a follow-up. Consider returning a default or throwing with a clearer message.
-
-### 🟡 MEDIUM — Tie-breaking inconsistency (`ScoredCandidate.cs:18-20`)
+## 🟡 MEDIUM — Tie-breaking inconsistency (`ScoredCandidate.cs:18-20`)
 
 ```csharp
 public override int Compare(ScoredCandidate<T> x, ScoredCandidate<T> y)

--- a/docs/optimize-extract-methods-review.md
+++ b/docs/optimize-extract-methods-review.md
@@ -31,11 +31,6 @@ The new score-only `ScoredCandidateComparer<T>` matches the previous `ExtractedR
 
 Every thread that finds a qualifying candidate acquires the lock. For large datasets with many candidates above cutoff, this serializes all merges. Consider merging locally first (already done), then doing one final merge at the end instead of locking per-thread.
 
-### 🟢 LOW — Minor inefficiencies
-
-- **Redundant variable** (`ResultExtractor.cs:51`): `var comparer = ScoredCandidateComparer<T>.Instance;` — already stored in MinHeap constructor
-- **Double `.Instance` access** on lines 50-51 of the same file
-
 ---
 
 ## ✅ Good Patterns

--- a/docs/optimize-extract-methods-review.md
+++ b/docs/optimize-extract-methods-review.md
@@ -8,7 +8,7 @@
 
 ## Summary
 
-Refactored `ResultExtractor` to eliminate double-iteration from LINQ `.Max()` / `.MaxN(limit).Reverse()` chains. Introduced single-pass extraction with dedicated core methods and a min-heap for top-N selection.
+Refactored `ResultExtractor` to select the best and top-N results directly, avoiding intermediate `ExtractedResult` allocations. The prior LINQ pipelines already enumerated their input once; this change reduces per-candidate overhead while preserving their selection behavior.
 
 **Files changed:**
 | File | Change |
@@ -23,28 +23,9 @@ Refactored `ResultExtractor` to eliminate double-iteration from LINQ `.Max()` / 
 
 ## Findings
 
-### 🟡 MEDIUM — Silent null return on no-match (`ResultExtractor.cs:38`, `.Parallel.cs:51`)
+### ✅ Selection behavior is preserved
 
-```csharp
-return Enumerable.Empty<ExtractedResult<T>>().Max();
-```
-
-## 🟡 MEDIUM — Tie-breaking inconsistency (`ScoredCandidate.cs:18-20`)
-
-```csharp
-public override int Compare(ScoredCandidate<T> x, ScoredCandidate<T> y)
-{
-    return x.Score.CompareTo(y.Score);  // only compares score!
-}
-```
-
-When two candidates have equal scores, the comparer returns `0` without considering index. The old `.MaxN(limit)` preserved original order for ties; the heap-based approach may return arbitrary candidates. For deterministic results:
-
-```csharp
-int cmp = x.Score.CompareTo(y.Score);
-if (cmp != 0) return cmp;
-return x.Index.CompareTo(y.Index);
-```
+The new score-only `ScoredCandidateComparer<T>` matches the previous `ExtractedResult<T>.CompareTo` behavior used by `.MaxN(limit)`. Both implementations retain the same candidates and ordering for equal scores. `ExtractOne` continues to select the first highest-scoring candidate, while the parallel implementation resolves equal scores by their original index.
 
 ### 🟡 MEDIUM — Lock contention in parallel ExtractOne (`ResultExtractor.Parallel.cs:43-46`)
 
@@ -60,7 +41,7 @@ Every thread that finds a qualifying candidate acquires the lock. For large data
 ## ✅ Good Patterns
 
 - `BestCandidate<T>` struct with thread-local state for parallel merge is correct
-- Single-pass extraction eliminates double iteration (old code: score → Max/MaxN)
+- Direct selection avoids creating intermediate `ExtractedResult` instances for every candidate
 - Cutoff filtering before heap insertion avoids unnecessary allocations
 - `ScoreParallel` writes to distinct array indices — safe without synchronization
 
@@ -68,4 +49,4 @@ Every thread that finds a qualifying candidate acquires the lock. For large data
 
 ## Overall Assessment
 
-The refactoring is sound and achieves the stated goal of eliminating double-iteration. The main concern is the tie-breaking behavior change for equal-score candidates in ExtractTop, which could produce different results than before on edge cases.
+The refactoring is sound and reduces per-candidate allocation and selection overhead without changing the established tie-breaking behavior.

--- a/docs/optimize-extract-methods-review.md
+++ b/docs/optimize-extract-methods-review.md
@@ -1,0 +1,73 @@
+# Code Review: optimize-extract-methods Branch
+
+**Date:** 2026-07-01  
+**Branch:** `optimize-extract-methods` → `master`  
+**Diff:** +1,206 / -30 lines across 7 files
+
+---
+
+## Summary
+
+Refactored `ResultExtractor` to eliminate double-iteration from LINQ `.Max()` / `.MaxN(limit).Reverse()` chains. Introduced single-pass extraction with dedicated core methods and a min-heap for top-N selection.
+
+**Files changed:**
+| File | Change |
+|---|---|
+| `FuzzySharp\Extractor\ResultExtractor.cs` | Refactored — replaced LINQ Max/MaxN with `ExtractOneCore`, `ExtractTopCore` |
+| `FuzzySharp\Extractor\ScoredCandidate.cs` | **New** — `ScoredCandidate<T>`, `BestCandidate<T>` for single-best tracking |
+| `FuzzySharp\Extractor\ResultExtractor.Parallel.cs` | Parallel extractors use `BestCandidate<T>` with lock-based merging |
+| `FuzzySharp\Extractor\ResultExtractor.Cached.cs` | Cached variant refactoring |
+| `FuzzySharp\Extractor\ResultExtractor.Parallel.Cached.cs` | Cached parallel variant |
+
+---
+
+## Findings
+
+### 🔴 HIGH — Empty sequence throws on no-match (`ResultExtractor.cs:38`, `.Parallel.cs:51`)
+
+```csharp
+return Enumerable.Empty<ExtractedResult<T>>().Max();
+```
+
+When no candidates meet the cutoff, this calls `.Max()` on an empty `IEnumerable` and throws `InvalidOperationException`. This is a **pre-existing bug** (old code did the same), so functionally unchanged — but should be addressed in a follow-up. Consider returning a default or throwing with a clearer message.
+
+### 🟡 MEDIUM — Tie-breaking inconsistency (`ScoredCandidate.cs:18-20`)
+
+```csharp
+public override int Compare(ScoredCandidate<T> x, ScoredCandidate<T> y)
+{
+    return x.Score.CompareTo(y.Score);  // only compares score!
+}
+```
+
+When two candidates have equal scores, the comparer returns `0` without considering index. The old `.MaxN(limit)` preserved original order for ties; the heap-based approach may return arbitrary candidates. For deterministic results:
+
+```csharp
+int cmp = x.Score.CompareTo(y.Score);
+if (cmp != 0) return cmp;
+return x.Index.CompareTo(y.Index);
+```
+
+### 🟡 MEDIUM — Lock contention in parallel ExtractOne (`ResultExtractor.Parallel.cs:43-46`)
+
+Every thread that finds a qualifying candidate acquires the lock. For large datasets with many candidates above cutoff, this serializes all merges. Consider merging locally first (already done), then doing one final merge at the end instead of locking per-thread.
+
+### 🟢 LOW — Minor inefficiencies
+
+- **Redundant variable** (`ResultExtractor.cs:51`): `var comparer = ScoredCandidateComparer<T>.Instance;` — already stored in MinHeap constructor
+- **Double `.Instance` access** on lines 50-51 of the same file
+
+---
+
+## ✅ Good Patterns
+
+- `BestCandidate<T>` struct with thread-local state for parallel merge is correct
+- Single-pass extraction eliminates double iteration (old code: score → Max/MaxN)
+- Cutoff filtering before heap insertion avoids unnecessary allocations
+- `ScoreParallel` writes to distinct array indices — safe without synchronization
+
+---
+
+## Overall Assessment
+
+The refactoring is sound and achieves the stated goal of eliminating double-iteration. The main concern is the tie-breaking behavior change for equal-score candidates in ExtractTop, which could produce different results than before on edge cases.


### PR DESCRIPTION
Implements #29 

# PR Summary — optimize-extract-methods

Branch: `optimize-extract-methods`  
Head commit: `20a65f733843640636139da5eb8c5dc5286b7bd5`  
Commit message: "Refactor and optimize selection logic in ResultExtractor"

## Overview
Refactors the selection logic used by the `ResultExtractor` to improve performance and clarity when selecting best / top-N matches. Core extractor public APIs are preserved; internal selection was rewritten and extracted into smaller helpers and types.

## Key changes
- Added `ScoredCandidate<T>` (record-like readonly struct) and `ScoredCandidateComparer<T>` to represent scored items and provide simple score comparisons.
  - File: `FuzzySharp/FuzzySharp/Extractor/ScoredCandidate.cs`
- Introduced `BestCandidate<T>` helper to encapsulate "best so far" selection logic with a deterministic tie-breaker (prefer lower index on equal scores).
  - File: `FuzzySharp/FuzzySharp/Extractor/ScoredCandidate.cs`
- Refactored `ResultExtractor` internals:
  - `ExtractOneCore<T>`: simplified linear scan for best match using local tracking variables.
  - `ExtractTopCore<T>`: implemented top-N extraction using a `MinHeap<ScoredCandidate<T>>` to achieve O(n log k) behavior and lower overhead compared to full sorting.
  - Added helpers: `AddTopCandidate`, `CreateTopResults` to encapsulate heap logic and result materialization.
  - File: `FuzzySharp/FuzzySharp/Extractor/ResultExtractor.cs`

## Behavior / semantics
- Cutoff handling preserved: items with score < cutoff are ignored.
- Tie-breaking for best candidate: when scores are equal, the candidate with the smaller index (earlier in input) is preferred.
- Public extraction methods (`ExtractOne`, `ExtractTop`, `ExtractSorted`, `ExtractWithoutOrder`) keep the same signatures and behavior from the consumer perspective.

## Rationale / benefits
- Performance: top-N selection moved from potentially heavier sorting to a bounded heap approach (O(n log k)), reducing work and allocations when `limit << n`.
- Code clarity: extraction selection logic split into well-named helpers and small data types, improving maintainability and reusability.
- Deterministic tie-breaking added explicitly.

## Tests / verification
- Recommended tests:
  - Validate `ExtractTop` for correct top-N results and ordering with duplicates and ties.
  - Verify `ExtractOne` selects earliest index on equal scores.
  - Benchmarks comparing previous implementation (if available) and new heap-based approach for large `choices` and small `limit`.
- No test changes detected in this commit; consider adding micro-benchmarks for the top-N path.

## Files changed (approximate)
- Added / modified:
  - `FuzzySharp/FuzzySharp/Extractor/ScoredCandidate.cs` (new helpers / types)
  - `FuzzySharp/FuzzySharp/Extractor/ResultExtractor.cs` (refactored selection logic)

## Notes for reviewers
- Check `MinHeap` usage and `ScoredCandidateComparer<T>` for expected ordering semantics.
- Confirm no API regressions for edge cases (empty inputs, zero limit for `ExtractTop`, very large cutoffs).
- Consider unit / performance tests to lock behavior and measure improvement.
